### PR TITLE
Display resource URL together with status code on error messages

### DIFF
--- a/lib/almodovar/errors.rb
+++ b/lib/almodovar/errors.rb
@@ -1,3 +1,7 @@
 module Almodovar
-  class HttpError < Exception; end
+  class HttpError < Exception
+    def initialize(response, url)
+      super("Status code #{response.status} on resource #{url}")
+    end
+  end
 end

--- a/lib/almodovar/http_accessor.rb
+++ b/lib/almodovar/http_accessor.rb
@@ -3,7 +3,7 @@ module Almodovar
     def xml
       @xml ||= begin
         response = http.get(url_with_params)
-        check_errors(response)
+        check_errors(response, url_with_params)
         Nokogiri::XML.parse(response.body).root
       end
     end
@@ -29,8 +29,8 @@ module Almodovar
       end
     end
     
-    def check_errors(response)
-      raise(Almodovar::HttpError, "Status code: #{response.status}") if response.status >= 400
+    def check_errors(response, url)
+      raise(Almodovar::HttpError.new(response, url)) if response.status >= 400
     end
   end
   

--- a/lib/almodovar/resource_collection.rb
+++ b/lib/almodovar/resource_collection.rb
@@ -15,7 +15,7 @@ module Almodovar
       raise ArgumentError.new("You must specify one only root element which is the type of resource (e.g. `:project => { :name => 'Wadus' }` instead of just `:name => 'Wadus'`)") if attrs.size > 1
       root, body = attrs.first
       response = http.post(url_with_params, body.to_xml(:root => root, :convert_links => true, :skip_links_one_level => true), "Content-Type" => "application/xml")
-      check_errors(response)
+      check_errors(response, url_with_params)
       Resource.new(nil, @auth, Nokogiri::XML.parse(response.body).root)
     end
     

--- a/lib/almodovar/single_resource.rb
+++ b/lib/almodovar/single_resource.rb
@@ -16,12 +16,12 @@ module Almodovar
       raise ArgumentError.new("You must specify one only root element which is the type of resource (e.g. `:project => { :name => 'Wadus' }` instead of just `:name => 'Wadus'`)") if attrs.size > 1
       root, body = attrs.first
       response = http.put(@url, body.to_xml(:root => root), :content_type => "application/xml")
-      check_errors(response)
+      check_errors(response, @url)
       @xml = Nokogiri::XML.parse(response.body).root
     end
   
     def delete
-      check_errors(http.delete(@url))
+      check_errors(http.delete(@url), @url)
     end
   
     def url

--- a/spec/acceptance/errors_spec.rb
+++ b/spec/acceptance/errors_spec.rb
@@ -1,39 +1,47 @@
 require "spec_helper"
 
 describe "Errors should raise exceptions" do
+
+  let(:resource_url)  { "http://movida.example.com/resource" }
+  let(:resources_url) { "http://movida.example.com/resources" }
   
   %w{400 401 403 404 405 406 422 500 502 503}.each do |code|
     example "Receiving #{code} in a GET request" do
-      stub_auth_request(:get, "http://movida.example.com/resource").to_return(:body => '', :status => code.to_i)
+      stub_auth_request(:get, resource_url).to_return(:body => '', :status => code.to_i)
     
-      resource = Almodovar::Resource("http://movida.example.com/resource", auth)
-    
-      expect { resource.wadus }.to raise_error(Almodovar::HttpError, /#{code}/)
+      resource = Almodovar::Resource(resource_url, auth)
+
+      expect { resource.wadus }.to raise_error(Almodovar::HttpError, error_message(code, resource_url))
     end
     
     example "Receiving #{code} in a POST request" do
-      stub_auth_request(:post, "http://movida.example.com/resources").to_return(:body => '', :status => code.to_i)
+      stub_auth_request(:post, resources_url).to_return(:body => '', :status => code.to_i)
     
-      resources = Almodovar::Resource("http://movida.example.com/resources", auth)
+      resources = Almodovar::Resource(resources_url, auth)
     
-      expect { resources.create(:resource => {:wadus => 'wadus'}) }.to raise_error(Almodovar::HttpError, /#{code}/)
+      expect { resources.create(:resource => {:wadus => 'wadus'}) }.to raise_error(Almodovar::HttpError, error_message(code, resources_url))
     end
     
     example "Receiving #{code} in a PUT request" do
-      stub_auth_request(:put, "http://movida.example.com/resource").to_return(:body => '', :status => code.to_i)
+      stub_auth_request(:put, resource_url).to_return(:body => '', :status => code.to_i)
     
-      resource = Almodovar::Resource("http://movida.example.com/resource", auth)
+      resource = Almodovar::Resource(resource_url, auth)
     
-      expect { resource.update(:resource => {:wadus => 'wadus'}) }.to raise_error(Almodovar::HttpError, /#{code}/)
+      expect { resource.update(:resource => {:wadus => 'wadus'}) }.to raise_error(Almodovar::HttpError, error_message(code, resource_url))
     end
     
     example "Receiving #{code} in a DELETE request" do
-      stub_auth_request(:delete, "http://movida.example.com/resource").to_return(:body => '', :status => code.to_i)
+      stub_auth_request(:delete, resource_url).to_return(:body => '', :status => code.to_i)
     
-      resource = Almodovar::Resource("http://movida.example.com/resource", auth)
+      resource = Almodovar::Resource(resource_url, auth)
     
-      expect { resource.delete }.to raise_error(Almodovar::HttpError, /#{code}/)
+      expect { resource.delete }.to raise_error(Almodovar::HttpError, error_message(code, resource_url))
     end
   end
 
+  private
+
+  def error_message(code, url)
+    "Status code #{code} on resource #{url}"
+  end
 end


### PR DESCRIPTION
Given that error HTTP responses raise an exception that needs to be tracked, I thought that it might be helpful to include which is the resource that responded with an error, providing its URL in the error message.

Since this is my first contribution to Almodovar, your opinions will be very appreciated.
