### PR TITLE
Support links tag on updating

### DIFF
--- a/lib/almodovar/single_resource.rb
+++ b/lib/almodovar/single_resource.rb
@@ -1,66 +1,92 @@
 module Almodovar
   class SingleResource
     include HttpAccessor
-    
+
     undef_method :id if instance_methods.include?("id")
     undef_method :type if instance_methods.include?("type")
-        
+
     def initialize(url, auth, xml = nil, options = {})
-      @url = url
-      @auth = auth
-      @xml = xml
+      @url     = url
+      @auth    = auth
+      @xml     = xml
       @options = options
+      @links   = []
     end
-  
+
+    # Provide links in the following way:
+    #
+    # {
+    #   links: [
+    #     { rel: "brand", href: "http://movida.example.com/api/brands/1" }
+    #   ]
+    # }
+    def links(links = [])
+      @links = links
+      self
+    end
+
     def update(attrs = {})
       raise ArgumentError.new("You must specify one only root element which is the type of resource (e.g. `:project => { :name => 'Wadus' }` instead of just `:name => 'Wadus'`)") if attrs.size > 1
       root, body = attrs.first
-      response = http.put(@url, body.to_xml(:root => root), "Content-Type" => "application/xml")
+      built_body = build_body(body.to_xml(:root => root))
+      response = http.put(@url, built_body, "Content-Type" => "application/xml")
       check_errors(response, @url)
       @xml = Nokogiri::XML.parse(response.body).root
     end
-  
+
     def delete
       check_errors(http.delete(@url), @url)
     end
-  
+
     def url
       @url ||= xml.at_xpath("./link[@rel='self']").try(:[], "href")
     end
-  
+
     delegate :to_xml, :to => :xml
     alias_method :inspect, :to_xml
-    
+
     def [](key) # for resources with type "document"
       return super unless xml.at_xpath("/*[@type='document']")
       Hash.from_xml(xml.to_xml).values.first[key]
     end
-    
+
     def respond_to?(meth)
       super || (node(meth) != nil) || (link(meth) != nil)
     end
-  
+
     private
-  
+
+    def build_body(body)
+      Nokogiri::XML.parse(body).tap do |doc|
+        append_links(doc)
+      end.to_xml
+    end
+
+    def append_links(doc)
+      @links.map do |link|
+        doc.root << "<link rel=\"#{link[:rel]}\" href=\"#{link[:href]}\">\n"
+      end
+    end
+
     def method_missing(meth, *args, &blk)
       if node = node(meth)
         return node['type'] == 'document' ? Resource.from_xml(node.to_xml) : node_text(node)
       end
-    
+
       link = link(meth)
       return Resource.new(link["href"], @auth, link.at_xpath("./*"), *args) if link
-    
+
       super
     end
-    
+
     def node(name)
       xml.at_xpath("./*[name()='#{name}' or name()='#{attribute_name(name)}']")
     end
-    
+
     def link(name)
       xml.at_xpath("./link[@rel='#{name}' or @rel='#{attribute_name(name)}']")
     end
-  
+
     def node_text(node)
       case node['type']
       when "integer"
@@ -75,10 +101,10 @@ module Almodovar
         node.text
       end
     end
-  
+
     def attribute_name(attribute)
       attribute.to_s.gsub('_', '-')
     end
-  
+
   end
 end

--- a/spec/unit/single_resource_spec.rb
+++ b/spec/unit/single_resource_spec.rb
@@ -10,4 +10,44 @@ describe Almodovar::SingleResource do
 
     a_request(:put, "http://movida.bebanjo.com/titles/1").with(:headers => {'Content-Type' => "application/xml"}).should have_been_made
   end
+
+  context "#links" do
+    before do
+      @single_resource = Almodovar::SingleResource.new("http://movida.bebanjo.com/titles/1", nil)
+    end
+
+    it "return the same single resource instance" do
+      single_resource = @single_resource.links
+
+      expect(single_resource.class).to eq(Almodovar::SingleResource)
+    end
+
+    it "set links" do
+      expected_links  = [{ rel: "series", href: "http://example.com/api/series/1" }]
+      single_resource = @single_resource.links(expected_links)
+
+      expect(single_resource.instance_variable_get(:@links)).to eq(expected_links)
+    end
+
+    it "return xml with links" do
+      expected_links    = [{ rel: "series", href: "http://example.com/api/series/1" }]
+      xml_without_links = { "name" => "Kamikaze" }.to_xml(root: "title")
+      built_xml         = @single_resource.links(expected_links).send(:build_body, xml_without_links)
+
+      link_node = Nokogiri::XML.parse(built_xml).xpath("//title//link").first
+      expect(Nokogiri::XML.parse(built_xml).xpath("//title//link").count).to eq(1)
+      expect(link_node.name).to eq("link")
+      expect(link_node.attributes["rel"].name).to eq("rel")
+      expect(link_node.attributes["rel"].value).to eq("series")
+      expect(link_node.attributes["href"].name).to eq("href")
+      expect(link_node.attributes["href"].value).to eq("http://example.com/api/series/1")
+    end
+
+    it "return xml without links" do
+      xml_without_links = { "name" => "Kamikaze" }.to_xml(root: "title")
+      built_xml         = @single_resource.send(:build_body, xml_without_links)
+
+      expect(Nokogiri::XML.parse(built_xml).xpath("//title//link").count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
Support links tag on updating.

```ruby
 resource = Almodovar::SingleResource.new("http://movida.bebanjo.com/titles/1", nil)
 resource.links([{ rel: "series", href="http://movida.example.com/api/series/1" }]).update(:title => {"name" => "Kamikaze"})
```

will build the following xml:
```xml
<title>
  <name>Kamikaze</name>
  <link rel="series", href="http://movida.example.com/api/series/1" />
</title>
```