### PR TITLE
Added support to create links passing single resources

### DIFF
--- a/lib/almodovar/to_xml.rb
+++ b/lib/almodovar/to_xml.rb
@@ -11,8 +11,14 @@ module Almodovar
       end
     end
   end
-  
+
   class Resource
+    def to_xml(options = {})
+      options[:builder].tag!(:link, :rel => options[:root], :href => url)
+    end
+  end
+
+  class SingleResource
     def to_xml(options = {})
       options[:builder].tag!(:link, :rel => options[:root], :href => url)
     end

--- a/lib/almodovar/to_xml.rb
+++ b/lib/almodovar/to_xml.rb
@@ -20,7 +20,7 @@ module Almodovar
 
   class SingleResource
     def to_xml(options = {})
-      options[:builder].tag!(:link, :rel => options[:root], :href => url)
+      options[:builder].tag!(:link, :href => url, :rel => options[:root])
     end
   end
 end

--- a/spec/unit/single_resource_spec.rb
+++ b/spec/unit/single_resource_spec.rb
@@ -13,8 +13,8 @@ describe Almodovar::SingleResource do
 
   it "#to_xml" do
     builder = Builder::XmlMarkup.new
-    xml     = Almodovar::SingleResource.new("http://movida.bebanjo.com/titles/1", nil).to_xml(builder: builder, root: "series")
+    xml     = Almodovar::SingleResource.new("http://movida.bebanjo.com/series/1", nil).to_xml(:builder => builder, :root => "series")
 
-    expect(xml).to eq("<link rel=\"series\" href=\"http://movida.bebanjo.com/titles/1\"/>")
+    expect(xml).to eq("<link href=\"http://movida.bebanjo.com/series/1\" rel=\"series\"/>")
   end
 end

--- a/spec/unit/single_resource_spec.rb
+++ b/spec/unit/single_resource_spec.rb
@@ -10,4 +10,11 @@ describe Almodovar::SingleResource do
 
     a_request(:put, "http://movida.bebanjo.com/titles/1").with(:headers => {'Content-Type' => "application/xml"}).should have_been_made
   end
+
+  it "#to_xml" do
+    builder = Builder::XmlMarkup.new
+    xml     = Almodovar::SingleResource.new("http://movida.bebanjo.com/titles/1", nil).to_xml(builder: builder, root: "series")
+
+    expect(xml).to eq("<link rel=\"series\" href=\"http://movida.bebanjo.com/titles/1\"/>")
+  end
 end


### PR DESCRIPTION
This PR implements `#to_xml` method to `Almodovar::SingleResource` instances.

You can check the test for more information https://github.com/bebanjo/almodovar/pull/29/files#diff-a37a3ab2b146b679f8eda5a56c0a4d52R14