### PR TITLE
Update Almodovar::HttpError superclass

### DIFF
--- a/lib/almodovar/errors.rb
+++ b/lib/almodovar/errors.rb
@@ -1,5 +1,5 @@
 module Almodovar
-  class HttpError < Exception
+  class HttpError < StandardError
     attr_reader :response_status, :response_body
 
     def initialize(response, url)


### PR DESCRIPTION
allows use of rescue => e