### PR TITLE
Updated travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,24 @@
-before_install:
-  - gem update --system 2.1.11
-  - gem --version
+language: ruby
+sudo: false
+cache: bundler
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.6
-  - 2.2.2
-gemfile:
-  - Gemfile
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
+  - ruby-head
+  - jruby-9000
+  - jruby-9.0.1.0
+  - jruby-9.0.3.0
+  - jruby-head
+  - rbx-2
+
+matrix:
+  allow_failures:
+    - rvm: rbx-2
+    - rvm: jruby-head
+    - rvm: ruby-head
+    - rvm: jruby-9000
+    - rvm: jruby-9.0.1.0
+    - rvm: jruby-9.0.3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
     diff-lcs (1.2.5)
     httpclient (2.7.0.1)
     i18n (0.7.0)
-    json (1.8.1)
+    json (1.8.3)
     lorax (0.2.0)
       nokogiri (>= 1.4.0)
     multi_json (1.8.4)
@@ -57,4 +57,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
Updated travis file with more rubies versions.

Added the following keys:
* language: ruby => https://docs.travis-ci.com/user/travis-lint (validate .travis.yml)
* sudo: false => https://docs.travis-ci.com/user/workers/container-based-infrastructure/
* cache: bundler => https://docs.travis-ci.com/user/caching/#Bundler

Removed the folloing keys:
* gemfile: Gemfile => we don't need this line because Gemfile is the default.
* before_install => why we use this version? I think we don't need it, could you explain me?

Updated json version to 1.8.3 because version 1.8.1 doesn't work with ruby 2.3.0 