### PR TITLE
Timeout refactoring

### DIFF
--- a/lib/almodovar.rb
+++ b/lib/almodovar.rb
@@ -16,13 +16,26 @@ require 'almodovar/errors'
 require 'almodovar/to_xml'
 
 module Almodovar
-
   class << self
+    DEFAULT_SEND_TIMEOUT = 30
+    DEFAULT_CONNECT_TIMEOUT = 30
+    DEFAULT_RECEIVE_TIMEOUT = 30
+
     def default_options
-      @default_options ||= {
-        :timeout => 120,
-        :connect_timeout => 30,
-        :user_agent => "Almodovar/#{Almodovar::VERSION}"
+      default = {
+        send_timeout: DEFAULT_SEND_TIMEOUT,
+        connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+        receive_timeout: DEFAULT_RECEIVE_TIMEOUT,
+        user_agent: "Almodovar/#{Almodovar::VERSION}"
+      }
+      default.merge(@default_options || {})
+    end
+
+    def default_options=(options = {})
+      @default_options = {
+        send_timeout: options[:send_timeout],
+        connect_timeout: options[:connect_timeout],
+        receive_timeout: options[:receive_timeout]
       }
     end
   end

--- a/lib/almodovar.rb
+++ b/lib/almodovar.rb
@@ -17,9 +17,9 @@ require 'almodovar/to_xml'
 
 module Almodovar
   class << self
-    DEFAULT_SEND_TIMEOUT = 30
+    DEFAULT_SEND_TIMEOUT = 120
     DEFAULT_CONNECT_TIMEOUT = 30
-    DEFAULT_RECEIVE_TIMEOUT = 30
+    DEFAULT_RECEIVE_TIMEOUT = 120
 
     def default_options
       default = {

--- a/lib/almodovar/errors.rb
+++ b/lib/almodovar/errors.rb
@@ -8,4 +8,7 @@ module Almodovar
       super("Status code #{response.status} on resource #{url}")
     end
   end
+
+  class TimeoutError < StandardError
+  end
 end

--- a/lib/almodovar/errors.rb
+++ b/lib/almodovar/errors.rb
@@ -11,4 +11,13 @@ module Almodovar
 
   class TimeoutError < StandardError
   end
+
+  class SendTimeoutError < TimeoutError
+  end
+
+  class ReceiveTimeoutError < TimeoutError
+  end
+
+  class ConnectTimeoutError < TimeoutError
+  end
 end

--- a/lib/almodovar/http_accessor.rb
+++ b/lib/almodovar/http_accessor.rb
@@ -7,18 +7,19 @@ module Almodovar
         Nokogiri::XML.parse(response.body).root
       end
     end
-    
+
     def url_with_params
       @options[:expand] = @options[:expand].join(",") if @options[:expand].is_a?(Array)
       params = @options.map { |k, v| "#{k}=#{v}" }.join("&")
       params = "?#{params}" unless params.empty?
       @url + params
     end
-    
+
     def http
       @http ||= Almodovar::HttpClient.new.tap do |session|
-        session.timeout  = Almodovar::default_options[:timeout]
+        session.send_timeout = Almodovar::default_options[:send_timeout]
         session.connect_timeout = Almodovar::default_options[:connect_timeout]
+        session.receive_timeout = Almodovar::default_options[:receive_timeout]
         session.agent_name = Almodovar::default_options[:user_agent]
 
         if @auth
@@ -28,10 +29,9 @@ module Almodovar
         end
       end
     end
-    
+
     def check_errors(response, url)
       raise(Almodovar::HttpError.new(response, url)) if response.status >= 400
     end
   end
-  
 end

--- a/lib/almodovar/http_client.rb
+++ b/lib/almodovar/http_client.rb
@@ -2,7 +2,6 @@ require 'httpclient'
 
 module Almodovar
   class HttpClient
-
     attr_accessor :client,
                   :headers,
                   :username,
@@ -11,12 +10,9 @@ module Almodovar
 
     delegate :agent_name=,
              :connect_timeout=,
+             :send_timeout=,
+             :receive_timeout=,
              :to => :client
-
-
-    def timeout=(value)
-      client.send_timeout = value
-    end
 
     def initialize
       @client = HTTPClient.new
@@ -79,6 +75,8 @@ module Almodovar
         set_client_auth(domain)
       end
       client.request(method, uri, :body => options[:body], :header => options[:headers].stringify_keys || {}, :follow_redirect => true)
+    rescue HTTPClient::TimeoutError => e
+      raise TimeoutError.new(e)
     end
   end
 
@@ -100,5 +98,4 @@ module Almodovar
   class HttpResponse
     attr_accessor :status, :body
   end
-
 end

--- a/lib/almodovar/http_client.rb
+++ b/lib/almodovar/http_client.rb
@@ -75,8 +75,12 @@ module Almodovar
         set_client_auth(domain)
       end
       client.request(method, uri, :body => options[:body], :header => options[:headers].stringify_keys || {}, :follow_redirect => true)
-    rescue HTTPClient::TimeoutError => e
-      raise TimeoutError.new(e)
+    rescue HTTPClient::SendTimeoutError => e
+      raise SendTimeoutError.new(e)
+    rescue HTTPClient::ReceiveTimeoutError => e
+      raise ReceiveTimeoutError.new(e)
+    rescue HTTPClient::ConnectTimeoutError => e
+      raise ConnectTimeoutError.new(e)
     end
   end
 

--- a/spec/acceptance/timeout_spec.rb
+++ b/spec/acceptance/timeout_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe "Timeout" do
+  context "raise Almodovar::HttpClient::TimeoutError exception" do
+    it "for get" do
+      project = Almodovar::Resource("http://movida.example.com/projects/1", auth)
+
+      stub_auth_request(:get, "http://movida.example.com/projects/1").to_timeout
+
+      expect {
+        project.name
+      }.to raise_error(Almodovar::TimeoutError)
+    end
+
+    it "for create" do
+      projects = Almodovar::Resource("http://movida.example.com/projects", auth)
+
+      stub_auth_request(:post, "http://movida.example.com/projects").to_timeout
+
+      expect {
+        projects.create(project: { name: "Wadus"})
+      }.to raise_error(Almodovar::TimeoutError)
+    end
+
+    it "for put" do
+      projects = Almodovar::Resource("http://movida.example.com/projects/1", auth)
+
+      stub_auth_request(:put, "http://movida.example.com/projects/1").to_timeout
+
+      expect {
+        projects.update(project: { name: "Wadus"})
+      }.to raise_error(Almodovar::TimeoutError)
+    end
+
+    it "for delete" do
+      projects = Almodovar::Resource("http://movida.example.com/projects/1", auth)
+
+      stub_auth_request(:delete, "http://movida.example.com/projects/1").to_timeout
+
+      expect {
+        projects.delete
+      }.to raise_error(Almodovar::TimeoutError)
+    end
+  end
+end

--- a/spec/acceptance/timeout_spec.rb
+++ b/spec/acceptance/timeout_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Timeout" do
-  context "raise Almodovar::HttpClient::TimeoutError exception" do
+  context "raise Almodovar::TimeoutError exception" do
     it "for get" do
       project = Almodovar::Resource("http://movida.example.com/projects/1", auth)
 

--- a/spec/acceptance/timeout_spec.rb
+++ b/spec/acceptance/timeout_spec.rb
@@ -2,44 +2,48 @@ require 'spec_helper'
 
 describe "Timeout" do
   context "raise Almodovar::TimeoutError exception" do
-    it "for get" do
-      project = Almodovar::Resource("http://movida.example.com/projects/1", auth)
+    [[HTTPClient::SendTimeoutError, Almodovar::SendTimeoutError],
+     [HTTPClient::ReceiveTimeoutError, Almodovar::ReceiveTimeoutError],
+     [HTTPClient::ConnectTimeoutError, Almodovar::ConnectTimeoutError]].each do |httpclient_exception, almodovar_exception|
+      it "for get" do
+        project = Almodovar::Resource("http://movida.example.com/projects/1", auth)
 
-      stub_auth_request(:get, "http://movida.example.com/projects/1").to_timeout
+        stub_auth_request(:get, "http://movida.example.com/projects/1").to_raise(httpclient_exception)
 
-      expect {
-        project.name
-      }.to raise_error(Almodovar::TimeoutError)
-    end
+        expect {
+          project.name
+        }.to raise_error(almodovar_exception)
+      end
 
-    it "for create" do
-      projects = Almodovar::Resource("http://movida.example.com/projects", auth)
+      it "for create" do
+        projects = Almodovar::Resource("http://movida.example.com/projects", auth)
 
-      stub_auth_request(:post, "http://movida.example.com/projects").to_timeout
+        stub_auth_request(:post, "http://movida.example.com/projects").to_raise(httpclient_exception)
 
-      expect {
-        projects.create(project: { name: "Wadus"})
-      }.to raise_error(Almodovar::TimeoutError)
-    end
+        expect {
+          projects.create(project: { name: "Wadus"})
+        }.to raise_error(almodovar_exception)
+      end
 
-    it "for put" do
-      projects = Almodovar::Resource("http://movida.example.com/projects/1", auth)
+      it "for put" do
+        projects = Almodovar::Resource("http://movida.example.com/projects/1", auth)
 
-      stub_auth_request(:put, "http://movida.example.com/projects/1").to_timeout
+        stub_auth_request(:put, "http://movida.example.com/projects/1").to_raise(httpclient_exception)
 
-      expect {
-        projects.update(project: { name: "Wadus"})
-      }.to raise_error(Almodovar::TimeoutError)
-    end
+        expect {
+          projects.update(project: { name: "Wadus"})
+        }.to raise_error(almodovar_exception)
+      end
 
-    it "for delete" do
-      projects = Almodovar::Resource("http://movida.example.com/projects/1", auth)
+      it "for delete" do
+        projects = Almodovar::Resource("http://movida.example.com/projects/1", auth)
 
-      stub_auth_request(:delete, "http://movida.example.com/projects/1").to_timeout
+        stub_auth_request(:delete, "http://movida.example.com/projects/1").to_raise(httpclient_exception)
 
-      expect {
-        projects.delete
-      }.to raise_error(Almodovar::TimeoutError)
+        expect {
+          projects.delete
+        }.to raise_error(almodovar_exception)
+      end
     end
   end
 end

--- a/spec/unit/default_options_spec.rb
+++ b/spec/unit/default_options_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Almodovar do
+  describe '.default_options' do
+    before do
+      Almodovar.default_options = {
+        send_timeout: 0.2,
+        connect_timeout: 0.2,
+        receive_timeout: 0.2
+      }
+    end
+
+    it 'should return set default_options' do
+      expect(Almodovar.default_options[:send_timeout]).to eq(0.2)
+      expect(Almodovar.default_options[:connect_timeout]).to eq(0.2)
+      expect(Almodovar.default_options[:receive_timeout]).to eq(0.2)
+      expect(Almodovar.default_options[:user_agent]).to eq("Almodovar/#{Almodovar::VERSION}")
+    end
+
+    it 'can overwrite default_options' do
+      Almodovar.default_options = {
+        send_timeout: 0.1,
+        connect_timeout: 0.5,
+        receive_timeout: 0.3
+      }
+
+      expect(Almodovar.default_options[:send_timeout]).to eq(0.1)
+      expect(Almodovar.default_options[:connect_timeout]).to eq(0.5)
+      expect(Almodovar.default_options[:receive_timeout]).to eq(0.3)
+      expect(Almodovar.default_options[:user_agent]).to eq("Almodovar/#{Almodovar::VERSION}")
+    end
+
+    it "can't overwrite user agent" do
+      Almodovar.default_options = {
+        user_agent: "Almodovar user agent"
+      }
+
+      expect(Almodovar.default_options[:user_agent]).to eq("Almodovar/#{Almodovar::VERSION}")
+    end
+  end
+end


### PR DESCRIPTION
Added `receive_timeout` and renamed `timeout` to `send_timeout` for consistency.

I added custom Almodovar::TimeoutError for better integration with other gems instead the raise the "native" timeout from httpclient gem.

Added ability to set default options (timeouts)