### PR TITLE
Handle HTTPClient::TimeoutError

### DIFF
--- a/lib/almodovar/http_client.rb
+++ b/lib/almodovar/http_client.rb
@@ -81,6 +81,8 @@ module Almodovar
       raise ReceiveTimeoutError.new(e)
     rescue HTTPClient::ConnectTimeoutError => e
       raise ConnectTimeoutError.new(e)
+    rescue HTTPClient::TimeoutError => e
+      raise TimeoutError.new(e)
     end
   end
 

--- a/spec/acceptance/timeout_spec.rb
+++ b/spec/acceptance/timeout_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe "Timeout" do
   context "raise Almodovar::TimeoutError exception" do
-    [[HTTPClient::SendTimeoutError, Almodovar::SendTimeoutError],
+    [[HTTPClient::TimeoutError, Almodovar::TimeoutError],
+     [HTTPClient::SendTimeoutError, Almodovar::SendTimeoutError],
      [HTTPClient::ReceiveTimeoutError, Almodovar::ReceiveTimeoutError],
      [HTTPClient::ConnectTimeoutError, Almodovar::ConnectTimeoutError]].each do |httpclient_exception, almodovar_exception|
       it "for get" do


### PR DESCRIPTION
In addition to the rest of the HTTPClient Timeout errors, we need to handle the main `TimeoutError` exception.