### PR TITLE
Fix respond_to? signature to match Object signature

### DIFF
--- a/lib/almodovar/resource.rb
+++ b/lib/almodovar/resource.rb
@@ -22,8 +22,8 @@ module Almodovar
       resource_object(meth).send(meth, *args, &blk)
     end
 
-    def respond_to?(meth)
-      super || resource_object(meth).respond_to?(meth)
+    def respond_to?(meth, include_all=false)
+      super || resource_object(meth).respond_to?(meth, include_all)
     end
 
     private

--- a/lib/almodovar/single_resource.rb
+++ b/lib/almodovar/single_resource.rb
@@ -36,7 +36,7 @@ module Almodovar
       Hash.from_xml(xml.to_xml).values.first[key]
     end
     
-    def respond_to?(meth)
+    def respond_to?(meth, include_all=false)
       super || (node(meth) != nil) || (link(meth) != nil)
     end
   


### PR DESCRIPTION
Silences warning for "old fashion which takes only one parameter"

```
warning: Almodovar::Resource#respond_to?(:to_ary) is old fashion which takes only one parameter
.../almodovar/lib/almodovar/resource.rb:25: warning: respond_to? is defined here
```