### PR TITLE
Remove username/password validation in HttpClient

### DIFF
--- a/lib/almodovar/http_client.rb
+++ b/lib/almodovar/http_client.rb
@@ -70,8 +70,6 @@ module Almodovar
       uri = URI.parse(URI.escape(URI.unescape(uri)))
       if (requires_auth?)
         domain = domain_for(uri)
-        uri.user = username
-        uri.password = password
         set_client_auth(domain)
       end
       client.request(method, uri, :body => options[:body], :header => options[:headers].stringify_keys || {}, :follow_redirect => true)

--- a/spec/unit/http_client_spec.rb
+++ b/spec/unit/http_client_spec.rb
@@ -13,4 +13,17 @@ describe Almodovar::HttpClient do
 
     a_request(:get, "http://www.bebanjo.com").with(:headers => {'Foo' => 'Bar', 'Baz' => 'Oink'}).should have_been_made
   end
+
+  it "allows URI escaped characters in password" do
+    stub_request(:get, "http://username:%5B%5D@www.bebanjo.com/")
+
+    client = Almodovar::HttpClient.new.tap do |client|
+      client.username = 'username'
+      client.password = '[]'
+    end
+
+    client.get("http://www.bebanjo.com")
+
+    a_request(:get, "http://username:%5B%5D@www.bebanjo.com").should have_been_made
+  end
 end


### PR DESCRIPTION
Fixes issue where URI escaped characters are not allowed in usernames or
passwords. The underlying httpclient gem will automatically escape these
characters, so there is no need to validate them beforehand.

Fixes #38