### PR TITLE
Fix error encoding values in the query string

### DIFF
--- a/lib/almodovar/http_accessor.rb
+++ b/lib/almodovar/http_accessor.rb
@@ -10,7 +10,7 @@ module Almodovar
 
     def url_with_params
       @options[:expand] = @options[:expand].join(",") if @options[:expand].is_a?(Array)
-      params = @options.map { |k, v| "#{k}=#{v}" }.join("&")
+      params = @options.to_query
       params = "?#{params}" unless params.empty?
       @url + params
     end

--- a/lib/almodovar/http_client.rb
+++ b/lib/almodovar/http_client.rb
@@ -67,7 +67,7 @@ module Almodovar
     end
 
     def request(method, uri, options = {})
-      uri = URI.parse(URI.escape(URI.unescape(uri)))
+      uri = URI.parse(uri)
       if (requires_auth?)
         domain = domain_for(uri)
         set_client_auth(domain)

--- a/spec/acceptance/fetch_resource_collections_spec.rb
+++ b/spec/acceptance/fetch_resource_collections_spec.rb
@@ -25,33 +25,20 @@ describe "Fetching resource collections" do
   end
 
   example "Fetch a collection with params" do
-    stub_auth_request(:get, "http://movida.example.com/resources?name=Jon%20Snow").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resources?name=Jon%20Snow&parents=Eddard%20%26%20Lyanna%20Stark").to_return(:body => %q{
       <resources type='array'>
         <resource>
           <name>Jon Snow</name>
+          <parents>Eddard &amp; Lyanna Stark</parents>
         </resource>
       </resources>
     })
 
-    resources = Almodovar::Resource("http://movida.example.com/resources", auth, :name => "Jon Snow")
+    resources = Almodovar::Resource("http://movida.example.com/resources", auth, :name => "Jon Snow", :parents => "Eddard & Lyanna Stark")
 
     resources.size.should == 1
     resources.first.name.should == "Jon Snow"
-  end
-
-  example "Fetch a collection with params unescaped in the url" do
-    stub_auth_request(:get, "http://movida.example.com/resources?name=Jon%20Snow").to_return(:body => %q{
-      <resources type='array'>
-        <resource>
-          <name>Jon Snow</name>
-        </resource>
-      </resources>
-    })
-
-    resources = Almodovar::Resource("http://movida.example.com/resources?name=Jon Snow", auth)
-
-    resources.size.should == 1
-    resources.first.name.should == "Jon Snow"
+    resources.first.parents.should == "Eddard & Lyanna Stark"
   end
 
   example "Fetch a collection with params escaped in the url" do


### PR DESCRIPTION
This PR replaces the manual query string encoding that was being done in [`Almodovar::HttpAccessor#url_with_params`](https://github.com/bebanjo/almodovar/blob/a6be9fda705e43ac4fc8cda023ea749cae47b153/lib/almodovar/http_accessor.rb#L13) with `Hash#to_query`, which will correctly encode the `&` character among others.

I'm also removing the escaping/unscaping that was introduced in #36, since it made it impossible to use the `&` character in GET request query string params.

For example, this Almodovar query:

``` ruby
resources = Almodovar::Resource(
  "http://movida.example.com/resources", 
  auth, 
  :name => "Hansel & Gretel"
)
```

Resulted in a request to:

```
http://user:password@movida.example.com/resources?%20Gretel&name=Hansel%20
```

With this change the request would be correctly encoded:

```
http://user:password@movida.example.com/resources?name=Hansel%20%26%20Gretel
```
## Important

This change could break existing client code, sending querystring params already encoded will no longer be valid.

Using the previous example, if I pre-encode the params:

``` ruby
resources = Almodovar::Resource(
  "http://movida.example.com/resources", 
  auth, 
  :name => "Hansel%20%26%20Gretel"
)
```

The following request will be made:

```
http://user:password@movida.example.com/resources?name=Hansel%2520%2526%2520Gretel
```
