### PR TITLE
HTTPClient force_basic_auth setting.

### DIFF
--- a/lib/almodovar.rb
+++ b/lib/almodovar.rb
@@ -16,17 +16,18 @@ require 'almodovar/errors'
 require 'almodovar/to_xml'
 
 module Almodovar
-  class << self
-    DEFAULT_SEND_TIMEOUT = 120
-    DEFAULT_CONNECT_TIMEOUT = 30
-    DEFAULT_RECEIVE_TIMEOUT = 120
+  DEFAULT_SEND_TIMEOUT = 120
+  DEFAULT_CONNECT_TIMEOUT = 30
+  DEFAULT_RECEIVE_TIMEOUT = 120
 
+  class << self
     def default_options
       default = {
         send_timeout: DEFAULT_SEND_TIMEOUT,
         connect_timeout: DEFAULT_CONNECT_TIMEOUT,
         receive_timeout: DEFAULT_RECEIVE_TIMEOUT,
-        user_agent: "Almodovar/#{Almodovar::VERSION}"
+        user_agent: "Almodovar/#{Almodovar::VERSION}",
+        force_basic_auth: false
       }
       default.merge(@default_options || {})
     end
@@ -35,7 +36,8 @@ module Almodovar
       @default_options = {
         send_timeout: options[:send_timeout],
         connect_timeout: options[:connect_timeout],
-        receive_timeout: options[:receive_timeout]
+        receive_timeout: options[:receive_timeout],
+        force_basic_auth: options[:force_basic_auth]
       }
     end
   end

--- a/lib/almodovar/http_accessor.rb
+++ b/lib/almodovar/http_accessor.rb
@@ -23,6 +23,7 @@ module Almodovar
         session.agent_name = Almodovar::default_options[:user_agent]
 
         if @auth
+          session.force_basic_auth = Almodovar::default_options[:force_basic_auth]
           session.username = @auth.username
           session.password = @auth.password
           session.auth_type = :digest

--- a/lib/almodovar/http_client.rb
+++ b/lib/almodovar/http_client.rb
@@ -12,6 +12,7 @@ module Almodovar
              :connect_timeout=,
              :send_timeout=,
              :receive_timeout=,
+             :force_basic_auth=,
              :to => :client
 
     def initialize

--- a/spec/unit/default_options_spec.rb
+++ b/spec/unit/default_options_spec.rb
@@ -2,32 +2,27 @@ require 'spec_helper'
 
 describe Almodovar do
   describe '.default_options' do
-    before do
-      Almodovar.default_options = {
-        send_timeout: 0.2,
-        connect_timeout: 0.2,
-        receive_timeout: 0.2
-      }
-    end
-
     it 'should return set default_options' do
-      expect(Almodovar.default_options[:send_timeout]).to eq(0.2)
-      expect(Almodovar.default_options[:connect_timeout]).to eq(0.2)
-      expect(Almodovar.default_options[:receive_timeout]).to eq(0.2)
+      expect(Almodovar.default_options[:send_timeout]).to eq(Almodovar::DEFAULT_SEND_TIMEOUT)
+      expect(Almodovar.default_options[:connect_timeout]).to eq(Almodovar::DEFAULT_CONNECT_TIMEOUT)
+      expect(Almodovar.default_options[:receive_timeout]).to eq(Almodovar::DEFAULT_RECEIVE_TIMEOUT)
       expect(Almodovar.default_options[:user_agent]).to eq("Almodovar/#{Almodovar::VERSION}")
+      expect(Almodovar.default_options[:force_basic_auth]).to eq(false)
     end
 
     it 'can overwrite default_options' do
       Almodovar.default_options = {
         send_timeout: 0.1,
         connect_timeout: 0.5,
-        receive_timeout: 0.3
+        receive_timeout: 0.3,
+        force_basic_auth: true
       }
 
       expect(Almodovar.default_options[:send_timeout]).to eq(0.1)
       expect(Almodovar.default_options[:connect_timeout]).to eq(0.5)
       expect(Almodovar.default_options[:receive_timeout]).to eq(0.3)
       expect(Almodovar.default_options[:user_agent]).to eq("Almodovar/#{Almodovar::VERSION}")
+      expect(Almodovar.default_options[:force_basic_auth]).to eq(true)
     end
 
     it "can't overwrite user agent" do


### PR DESCRIPTION
This setting is relevant when in an application that uses Almodovar and uses Webmock (>= 2.0) as http mocking library you want to ensure you’re providing proper authorisation headers on your test.

With this HTTPClient will send authorisation headers in every requests and not only as a response to a 401 status code from the server (that probably during your test is something you’re not setting). 

FYI: https://github.com/nahi/httpclient/commit/5be11cb40bc1393b65795c6c978ced007ea4d26a