### PR TITLE
Query params

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem 'rake'
 gem 'rspec'
-gem 'webmock'
+gem 'webmock', '2.3.2' # Last ruby 1.9 support
 gem 'safe_yaml', '>= 1.0.4'
 gem 'lorax'
 gem 'rdoc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     almodovar (1.5.5)
       activesupport
+      addressable (>= 2.3.6)
       builder
       httpclient (~> 2.5)
       i18n

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,11 +17,12 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.5)
+    addressable (2.3.6)
     builder (3.2.3)
-    crack (0.4.2)
+    crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
+    hashdiff (0.3.7)
     httpclient (2.8.3)
     i18n (0.8.1)
     json (1.8.3)
@@ -32,21 +33,27 @@ GEM
     rake (10.1.1)
     rdoc (4.1.1)
       json (~> 1.4)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.7)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.5)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
     safe_yaml (1.0.4)
     thread_safe (0.3.6)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
-    webmock (1.17.2)
-      addressable (>= 2.2.7)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
       crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -60,7 +67,7 @@ DEPENDENCIES
   rdoc
   rspec
   safe_yaml (>= 1.0.4)
-  webmock
+  webmock (= 2.3.2)
 
 BUNDLED WITH
-   1.16.0.pre.2
+   1.16.1

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ Bundler::GemHelper.install_tasks
 require 'rspec/core/rake_task'
 
 desc 'Default: run specs.'
-task :default => :spec
+task default: :spec
 
 desc "Run all specs"
 RSpec::Core::RakeTask.new("spec") do |t|
@@ -31,4 +31,4 @@ Rake::RDocTask.new do |rd|
 end
 
 desc 'Clear out RDoc and generated packages'
-task :clean => [:clobber_rdoc, :clobber_package]
+task clean: [:clobber_rdoc, :clobber_package]

--- a/almodovar.gemspec
+++ b/almodovar.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("activesupport")
   s.add_runtime_dependency("i18n")
   s.add_runtime_dependency("httpclient", "~> 2.5")
+  s.add_runtime_dependency("addressable", ">= 2.3.6")
   s.add_runtime_dependency("json")
 end

--- a/lib/almodovar/errors.rb
+++ b/lib/almodovar/errors.rb
@@ -3,10 +3,12 @@ module Almodovar
     attr_reader :response_status, :response_body
 
     # Children of this class must not override the initialize method
-    def initialize(response, url)
+    def initialize(response, url, query_params = {})
       @response_status = response.status
       @response_body = response.body
-      super("Status code #{response.status} on resource #{url}")
+      message = "Status code #{response.status} on resource #{url}"
+      message += " with params: #{query_params.inspect}" if query_params.present?
+      super(message)
     end
   end
 

--- a/lib/almodovar/http_accessor.rb
+++ b/lib/almodovar/http_accessor.rb
@@ -2,17 +2,15 @@ module Almodovar
   module HttpAccessor
     def xml
       @xml ||= begin
-        response = http.get(url_with_params)
-        check_errors(response, url_with_params)
+        response = http.get(@url, query_params)
+        check_errors(response, @url, query_params)
         Nokogiri::XML.parse(response.body).root
       end
     end
 
-    def url_with_params
+    def query_params
       @options[:expand] = @options[:expand].join(",") if @options[:expand].is_a?(Array)
-      params = @options.map { |k, v| "#{k}=#{v}" }.join("&")
-      params = "?#{params}" unless params.empty?
-      @url + params
+      @options
     end
 
     def http
@@ -31,10 +29,10 @@ module Almodovar
       end
     end
 
-    def check_errors(response, url)
+    def check_errors(response, url, query_params = {})
       if response.status >= 400
         http_error_klass = Almodovar::HTTP_ERRORS[response.status] || Almodovar::HttpError
-        raise http_error_klass.new(response, url)
+        raise http_error_klass.new(response, url, query_params)
       end
     end
   end

--- a/lib/almodovar/http_client.rb
+++ b/lib/almodovar/http_client.rb
@@ -1,3 +1,4 @@
+require 'addressable/uri'
 require 'httpclient'
 
 module Almodovar
@@ -68,7 +69,7 @@ module Almodovar
     end
 
     def request(method, uri, options = {})
-      uri = URI.parse(uri)
+      uri = Addressable::URI.parse(uri)
       if (requires_auth?)
         domain = domain_for(uri)
         set_client_auth(domain)

--- a/lib/almodovar/http_client.rb
+++ b/lib/almodovar/http_client.rb
@@ -19,20 +19,20 @@ module Almodovar
       @client = HTTPClient.new
     end
 
-    def get(uri, headers = {})
-      request(:get, uri, headers: merge_headers(headers))
+    def get(uri, query = {}, headers = {})
+      request(:get, uri, query: query, headers: merge_headers(headers))
     end
 
-    def post(uri, data, headers = {})
-      request(:post, uri, body: data, headers: merge_headers(headers))
+    def post(uri, data, query = {}, headers = {})
+      request(:post, uri, body: data, query: query, headers: merge_headers(headers))
     end
 
-    def put(uri, data, headers = {})
-      request(:put, uri, body: data, headers: merge_headers(headers))
+    def put(uri, data, query = {}, headers = {})
+      request(:put, uri, body: data, query: query, headers: merge_headers(headers))
     end
 
-    def delete(uri, headers = {})
-      request(:delete, uri, headers: merge_headers(headers))
+    def delete(uri, query = {}, headers = {})
+      request(:delete, uri, query: query, headers: merge_headers(headers))
     end
 
     private
@@ -68,12 +68,18 @@ module Almodovar
     end
 
     def request(method, uri, options = {})
-      uri = URI.parse(URI.escape(URI.unescape(uri)))
+      uri = URI.parse(uri)
       if (requires_auth?)
         domain = domain_for(uri)
         set_client_auth(domain)
       end
-      client.request(method, uri, body: options[:body], header: options[:headers].stringify_keys || {}, follow_redirect: true)
+      request_options = {
+        body: options[:body],
+        header: options[:headers].stringify_keys || {},
+        follow_redirect: true
+      }
+      request_options[:query] = options[:query] if options[:query].present?
+      client.request(method, uri, request_options)
     rescue HTTPClient::SendTimeoutError => e
       raise SendTimeoutError.new(e)
     rescue HTTPClient::ReceiveTimeoutError => e

--- a/lib/almodovar/http_client.rb
+++ b/lib/almodovar/http_client.rb
@@ -13,26 +13,26 @@ module Almodovar
              :send_timeout=,
              :receive_timeout=,
              :force_basic_auth=,
-             :to => :client
+             to: :client
 
     def initialize
       @client = HTTPClient.new
     end
 
     def get(uri, headers = {})
-      request(:get, uri, :headers => merge_headers(headers))
+      request(:get, uri, headers: merge_headers(headers))
     end
 
     def post(uri, data, headers = {})
-      request(:post, uri, :body => data, :headers => merge_headers(headers))
+      request(:post, uri, body: data, headers: merge_headers(headers))
     end
 
     def put(uri, data, headers = {})
-      request(:put, uri, :body => data, :headers => merge_headers(headers))
+      request(:put, uri, body: data, headers: merge_headers(headers))
     end
 
     def delete(uri, headers = {})
-      request(:delete, uri, :headers => merge_headers(headers))
+      request(:delete, uri, headers: merge_headers(headers))
     end
 
     private
@@ -73,7 +73,7 @@ module Almodovar
         domain = domain_for(uri)
         set_client_auth(domain)
       end
-      client.request(method, uri, :body => options[:body], :header => options[:headers].stringify_keys || {}, :follow_redirect => true)
+      client.request(method, uri, body: options[:body], header: options[:headers].stringify_keys || {}, follow_redirect: true)
     rescue HTTPClient::SendTimeoutError => e
       raise SendTimeoutError.new(e)
     rescue HTTPClient::ReceiveTimeoutError => e

--- a/lib/almodovar/resource.rb
+++ b/lib/almodovar/resource.rb
@@ -5,7 +5,7 @@ module Almodovar
     undef_method :id if instance_methods.include?("id")
     undef_method :type if instance_methods.include?("type")
 
-    delegate :inspect, :to => :get!
+    delegate :inspect, to: :get!
 
     def self.from_xml(xml, auth = nil)
       new(nil, auth, Nokogiri::XML.parse(xml).root)

--- a/lib/almodovar/resource_collection.rb
+++ b/lib/almodovar/resource_collection.rb
@@ -5,7 +5,7 @@ module Almodovar
     
     PAGINATION_ENTITIES = ["self::total-entries", "self::link[@rel='next']", "self::link[@rel='prev']"].join('|').freeze
 
-    delegate :inspect, :to => :resources
+    delegate :inspect, to: :resources
 
     def initialize(url, auth, xml = nil, options = {})
       @url = url
@@ -17,7 +17,7 @@ module Almodovar
     def create(attrs = {})
       raise ArgumentError.new("You must specify one only root element which is the type of resource (e.g. `:project => { :name => 'Wadus' }` instead of just `:name => 'Wadus'`)") if attrs.size > 1
       root, body = attrs.first
-      response = http.post(url_with_params, body.to_xml(:root => root, :convert_links => true, :skip_links_one_level => true), "Content-Type" => "application/xml")
+      response = http.post(url_with_params, body.to_xml(root: root, convert_links: true, skip_links_one_level: true), "Content-Type" => "application/xml")
       check_errors(response, url_with_params)
       Resource.new(nil, @auth, Nokogiri::XML.parse(response.body).root)
     end

--- a/lib/almodovar/resource_collection.rb
+++ b/lib/almodovar/resource_collection.rb
@@ -2,7 +2,7 @@ module Almodovar
   class ResourceCollection
     include HttpAccessor
     include Enumerable
-    
+
     PAGINATION_ENTITIES = ["self::total-entries", "self::link[@rel='next']", "self::link[@rel='prev']"].join('|').freeze
 
     delegate :inspect, to: :resources
@@ -13,12 +13,12 @@ module Almodovar
       @xml = xml if options.empty?
       @options = options
     end
-    
+
     def create(attrs = {})
       raise ArgumentError.new("You must specify one only root element which is the type of resource (e.g. `:project => { :name => 'Wadus' }` instead of just `:name => 'Wadus'`)") if attrs.size > 1
       root, body = attrs.first
-      response = http.post(url_with_params, body.to_xml(root: root, convert_links: true, skip_links_one_level: true), "Content-Type" => "application/xml")
-      check_errors(response, url_with_params)
+      response = http.post(@url, body.to_xml(root: root, convert_links: true, skip_links_one_level: true), query_params, { "Content-Type" => "application/xml" })
+      check_errors(response, @url, query_params)
       Resource.new(nil, @auth, Nokogiri::XML.parse(response.body).root)
     end
 
@@ -41,16 +41,16 @@ module Almodovar
     def prev_page
       Resource.new(prev_url, @auth) if prev_url
     end
-    
+
     private
-    
+
     def resources
       @resources ||= begin
         xml.xpath("./*[not(#{PAGINATION_ENTITIES})]").
           map { |subnode| Resource.new(subnode.at_xpath("./link[@rel='self']").try(:[], "href"), @auth, subnode, @options) }
       end
     end
-    
+
     def method_missing(meth, *args, &blk)
       resources.send(meth, *args, &blk)
     end

--- a/lib/almodovar/single_resource.rb
+++ b/lib/almodovar/single_resource.rb
@@ -15,7 +15,7 @@ module Almodovar
     def update(attrs = {})
       raise ArgumentError.new("You must specify one only root element which is the type of resource (e.g. `:project => { :name => 'Wadus' }` instead of just `:name => 'Wadus'`)") if attrs.size > 1
       root, body = attrs.first
-      response = http.put(@url, body.to_xml(root: root), "Content-Type" => "application/xml")
+      response = http.put(@url, body.to_xml(root: root), {}, { "Content-Type" => "application/xml" })
       check_errors(response, @url)
       @xml = Nokogiri::XML.parse(response.body).root
     end

--- a/lib/almodovar/single_resource.rb
+++ b/lib/almodovar/single_resource.rb
@@ -15,7 +15,7 @@ module Almodovar
     def update(attrs = {})
       raise ArgumentError.new("You must specify one only root element which is the type of resource (e.g. `:project => { :name => 'Wadus' }` instead of just `:name => 'Wadus'`)") if attrs.size > 1
       root, body = attrs.first
-      response = http.put(@url, body.to_xml(:root => root), "Content-Type" => "application/xml")
+      response = http.put(@url, body.to_xml(root: root), "Content-Type" => "application/xml")
       check_errors(response, @url)
       @xml = Nokogiri::XML.parse(response.body).root
     end
@@ -41,7 +41,7 @@ module Almodovar
       end
     end
 
-    delegate :to_xml, :to => :xml
+    delegate :to_xml, to: :xml
     alias_method :inspect, :to_xml
 
     def [](key) # for resources with type "document"

--- a/lib/almodovar/to_xml.rb
+++ b/lib/almodovar/to_xml.rb
@@ -6,15 +6,15 @@ module Almodovar
 
     def to_xml_with_links(options = {}, &block)
       return to_xml_without_links(options, &block) if !options[:convert_links] || options.delete(:skip_links_one_level)
-      options[:builder].tag!(:link, :rel => options[:root]) do |xml|
-        to_xml_without_links options.merge(:skip_links_one_level => self.is_a?(Array)), &block
+      options[:builder].tag!(:link, rel: options[:root]) do |xml|
+        to_xml_without_links options.merge(skip_links_one_level: self.is_a?(Array)), &block
       end
     end
   end
   
   class Resource
     def to_xml(options = {})
-      options[:builder].tag!(:link, :rel => options[:root], :href => url)
+      options[:builder].tag!(:link, rel: options[:root], href: url)
     end
   end
 end

--- a/spec/acceptance/create_resource_spec.rb
+++ b/spec/acceptance/create_resource_spec.rb
@@ -13,19 +13,19 @@ describe "Creating new resources" do
       #   <name>Wadus</name>
       # </project>      
       Nokogiri::XML.parse(req.body).at_xpath("/project/name").text == "Wadus"
-    end.to_return(:body => %q{
+    end.to_return(body: %q{
       <project>
         <name>Wadus</name>
         <link rel="self" href="http://movida.example.com/projects/1"/>
       </project>
     })
     
-    project = projects.create(:project => {:name => "Wadus"})
+    project = projects.create(project: {name: "Wadus"})
     
     expect(project).to be_a(Almodovar::Resource)
     expect(project.name).to eq("Wadus")
     
-    stub_auth_request(:get, "http://movida.example.com/projects/1").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/projects/1").to_return(body: %q{
       <project>
         <name>Wadus</name>
         <link rel="self" href="http://movida.example.com/projects/1"/>
@@ -44,7 +44,7 @@ describe "Creating new resources" do
       xml = Nokogiri::XML.parse(req.body)
       xml.at_xpath("/project/name").text == "Wadus" &&
       xml.at_xpath("/project/template").text == "Basic"
-    end.to_return(:body => %q{
+    end.to_return(body: %q{
       <project>
         <name>Wadus</name>
         <template>Basic</template>
@@ -59,8 +59,8 @@ describe "Creating new resources" do
       </project>
     })
     
-    projects = Almodovar::Resource("http://movida.example.com/projects", auth, :expand => :tasks)    
-    project = projects.create(:project => {:name => "Wadus", :template => "Basic"})
+    projects = Almodovar::Resource("http://movida.example.com/projects", auth, expand: :tasks)    
+    project = projects.create(project: {name: "Wadus", template: "Basic"})
     
     expect(project).to be_a(Almodovar::Resource)
     expect(project.name).to eq("Wadus")
@@ -77,21 +77,21 @@ describe "Creating new resources" do
       # </project>
       xml = Nokogiri::XML.parse(req.body)
       xml.at_xpath("/project/link[@rel='owner'][@href='http://example.com/people/luismi'][not(node())]")
-    end.to_return(:body => %q{
+    end.to_return(body: %q{
       <project>
         <link rel="self" href="http://movida.example.com/projects/1"/>
         <link rel="owner" href="http://example.com/people/luismi"/>
       </project>
     })
     
-    project = projects.create(:project => {:owner => Almodovar::Resource("http://example.com/people/luismi")})
+    project = projects.create(project: {owner: Almodovar::Resource("http://example.com/people/luismi")})
     
     expect(project).to be_a(Almodovar::Resource)
     expect(project.owner.url).to eq("http://example.com/people/luismi")
   end
   
   example "Creating single nested resources" do
-    projects = Almodovar::Resource("http://movida.example.com/projects", auth, :expand => :tasks)
+    projects = Almodovar::Resource("http://movida.example.com/projects", auth, expand: :tasks)
     
     stub_auth_request(:post, "http://movida.example.com/projects?expand=tasks").with do |req|
       # <project>
@@ -106,7 +106,7 @@ describe "Creating new resources" do
       xml.at_xpath("/project/name").text == "Wadus" &&
       xml.at_xpath("/project/link[@rel='timeline']/timeline/name").text == "Start project" &&
       xml.at_xpath("/project/link[@rel='timeline']/timeline/link[@rel='wadus']/wadus") != nil
-    end.to_return(:body => %q{
+    end.to_return(body: %q{
       <project>
         <name>Wadus</name>
         <link rel="self" href="http://movida.example.com/projects/1"/>
@@ -118,7 +118,7 @@ describe "Creating new resources" do
       </project>
     })
     
-    project = projects.create(:project => {:name => "Wadus", :timeline => {:name => "Start project", :wadus => {}}})
+    project = projects.create(project: {name: "Wadus", timeline: {name: "Start project", wadus: {}}})
     
     expect(project).to be_a(Almodovar::Resource)
     expect(project.name).to eq("Wadus")
@@ -126,7 +126,7 @@ describe "Creating new resources" do
   end
   
   example "Creating multiple nested resources" do
-    projects = Almodovar::Resource("http://movida.example.com/projects", auth, :expand => :tasks)
+    projects = Almodovar::Resource("http://movida.example.com/projects", auth, expand: :tasks)
     
     stub_auth_request(:post, "http://movida.example.com/projects?expand=tasks").with do |req|
       # <project>
@@ -140,7 +140,7 @@ describe "Creating new resources" do
       # </project>
       xml = Nokogiri::XML.parse(req.body)
       xml.at_xpath("/project/link[@rel='tasks']/tasks[@type='array']/task/name").text == "Start project"
-    end.to_return(:body => %q{
+    end.to_return(body: %q{
       <project>
         <link rel="tasks" href="http://movida.example.com/projects/1/tasks">
           <tasks type="array">
@@ -152,7 +152,7 @@ describe "Creating new resources" do
       </project>
     })
     
-    project = projects.create(:project => {:tasks => [{:name => "Start project"}]})
+    project = projects.create(project: {tasks: [{name: "Start project"}]})
     
     expect(project).to be_a(Almodovar::Resource)
     expect(project.tasks.first.name).to eq("Start project")
@@ -168,7 +168,7 @@ describe "Creating new resources" do
       #   <name>Wadus</name>
       # </project>
       Nokogiri::XML.parse(req.body).at_xpath("/project/name").text == "Wadus"
-    end.to_return(:body => %q{
+    end.to_return(body: %q{
       <errors>
         <error>Name is taken</error>
       </errors>
@@ -176,7 +176,7 @@ describe "Creating new resources" do
 
     expect do
       begin
-        projects.create(:project => {:name => "Wadus"})
+        projects.create(project: {name: "Wadus"})
       rescue Almodovar::UnprocessableEntityError => exception
         expect(exception.errors?).to eq true
         expect(exception.error_messages).to eq ["Name is taken"]

--- a/spec/acceptance/create_resource_spec.rb
+++ b/spec/acceptance/create_resource_spec.rb
@@ -22,8 +22,8 @@ describe "Creating new resources" do
     
     project = projects.create(:project => {:name => "Wadus"})
     
-    project.should be_a(Almodovar::Resource)
-    project.name.should == "Wadus"
+    expect(project).to be_a(Almodovar::Resource)
+    expect(project.name).to eq("Wadus")
     
     stub_auth_request(:get, "http://movida.example.com/projects/1").to_return(:body => %q{
       <project>
@@ -32,7 +32,7 @@ describe "Creating new resources" do
       </project>
     })
     
-    project.name.should == Almodovar::Resource(project.url, auth).name
+    expect(project.name).to eq(Almodovar::Resource(project.url, auth).name)
   end
   
   example "Creating a resource expanding links" do
@@ -62,10 +62,10 @@ describe "Creating new resources" do
     projects = Almodovar::Resource("http://movida.example.com/projects", auth, :expand => :tasks)    
     project = projects.create(:project => {:name => "Wadus", :template => "Basic"})
     
-    project.should be_a(Almodovar::Resource)
-    project.name.should == "Wadus"
-    project.tasks.size.should == 1
-    project.tasks.first.name.should == "Starting Meeting"
+    expect(project).to be_a(Almodovar::Resource)
+    expect(project.name).to eq("Wadus")
+    expect(project.tasks.size).to eq(1)
+    expect(project.tasks.first.name).to eq("Starting Meeting")
   end
   
   example "Creating linking to existing resources" do
@@ -86,8 +86,8 @@ describe "Creating new resources" do
     
     project = projects.create(:project => {:owner => Almodovar::Resource("http://example.com/people/luismi")})
     
-    project.should be_a(Almodovar::Resource)
-    project.owner.url.should == "http://example.com/people/luismi"
+    expect(project).to be_a(Almodovar::Resource)
+    expect(project.owner.url).to eq("http://example.com/people/luismi")
   end
   
   example "Creating single nested resources" do
@@ -120,9 +120,9 @@ describe "Creating new resources" do
     
     project = projects.create(:project => {:name => "Wadus", :timeline => {:name => "Start project", :wadus => {}}})
     
-    project.should be_a(Almodovar::Resource)
-    project.name.should == "Wadus"
-    project.timeline.name.should == "Start project"
+    expect(project).to be_a(Almodovar::Resource)
+    expect(project.name).to eq("Wadus")
+    expect(project.timeline.name).to eq("Start project")
   end
   
   example "Creating multiple nested resources" do
@@ -154,8 +154,8 @@ describe "Creating new resources" do
     
     project = projects.create(:project => {:tasks => [{:name => "Start project"}]})
     
-    project.should be_a(Almodovar::Resource)
-    project.tasks.first.name.should == "Start project"
+    expect(project).to be_a(Almodovar::Resource)
+    expect(project.tasks.first.name).to eq("Start project")
   end
 
   example "Creating a resource raise UnprocessableEntityError" do

--- a/spec/acceptance/delete_resource_spec.rb
+++ b/spec/acceptance/delete_resource_spec.rb
@@ -5,7 +5,7 @@ describe "Deleting resources" do
   example "Deleting a resource" do
     project = Almodovar::Resource("http://movida.example.com/projects/1", auth)
     
-    stub_auth_request(:delete, "http://movida.example.com/projects/1").to_return(:status => 200)
+    stub_auth_request(:delete, "http://movida.example.com/projects/1").to_return(status: 200)
     
     project.delete
     
@@ -15,7 +15,7 @@ describe "Deleting resources" do
   example "Deleting a resource raise UnprocessableEntityError" do
     project = Almodovar::Resource("http://movida.example.com/projects/1", auth)
 
-    stub_auth_request(:delete, "http://movida.example.com/projects/1").to_return(:body => %q{
+    stub_auth_request(:delete, "http://movida.example.com/projects/1").to_return(body: %q{
       <errors>
         <error>Should delete existing tasks first</error>
       </errors>

--- a/spec/acceptance/delete_resource_spec.rb
+++ b/spec/acceptance/delete_resource_spec.rb
@@ -9,7 +9,7 @@ describe "Deleting resources" do
     
     project.delete
     
-    auth_request(:delete, "http://movida.example.com/projects/1").should have_been_made.once
+    expect(auth_request(:delete, "http://movida.example.com/projects/1")).to have_been_made.once
   end
 
   example "Deleting a resource raise UnprocessableEntityError" do

--- a/spec/acceptance/errors_spec.rb
+++ b/spec/acceptance/errors_spec.rb
@@ -12,9 +12,9 @@ describe "Errors should raise exceptions" do
       resource = Almodovar::Resource(resource_url, auth)
 
       expect { resource.wadus }.to raise_error{ |error|
-        error.should be_a(Almodovar::HttpError)
-        error.message.should == error_message(code, resource_url)
-        error.response_body.should == '<error>more info</error>'
+        expect(error).to be_a(Almodovar::HttpError)
+        expect(error.message).to eq(error_message(code, resource_url))
+        expect(error.response_body).to eq('<error>more info</error>')
       }
     end
 
@@ -24,9 +24,9 @@ describe "Errors should raise exceptions" do
       resources = Almodovar::Resource(resources_url, auth)
 
       expect { resources.create(:resource => {:wadus => 'wadus'}) }.to raise_error{ |error|
-        error.should be_a(Almodovar::HttpError)
-        error.message.should == error_message(code, resources_url)
-        error.response_body.should == '<error>more info</error>'
+        expect(error).to be_a(Almodovar::HttpError)
+        expect(error.message).to eq(error_message(code, resources_url))
+        expect(error.response_body).to eq('<error>more info</error>')
       }
     end
 
@@ -36,9 +36,9 @@ describe "Errors should raise exceptions" do
       resource = Almodovar::Resource(resource_url, auth)
 
       expect { resource.update(:resource => {:wadus => 'wadus'}) }.to raise_error{ |error|
-        error.should be_a(Almodovar::HttpError)
-        error.message.should == error_message(code, resource_url)
-        error.response_body.should == '<error>more info</error>'
+        expect(error).to be_a(Almodovar::HttpError)
+        expect(error.message).to eq(error_message(code, resource_url))
+        expect(error.response_body).to eq('<error>more info</error>')
       }
     end
 
@@ -48,9 +48,9 @@ describe "Errors should raise exceptions" do
       resource = Almodovar::Resource(resource_url, auth)
 
       expect { resource.delete }.to raise_error{ |error|
-        error.should be_a(Almodovar::HttpError)
-        error.message.should == error_message(code, resource_url)
-        error.response_body.should == '<error>more info</error>'
+        expect(error).to be_a(Almodovar::HttpError)
+        expect(error.message).to eq(error_message(code, resource_url))
+        expect(error.response_body).to eq('<error>more info</error>')
       }
     end
   end

--- a/spec/acceptance/errors_spec.rb
+++ b/spec/acceptance/errors_spec.rb
@@ -55,9 +55,23 @@ describe "Errors should raise exceptions" do
     end
   end
 
+  example "Receiving a failure in a GET request with query params" do
+    stub_auth_request(:get, resource_url + "?page=2").to_return(body: '<error>more info</error>', status: 400)
+
+    resource = Almodovar::Resource(resource_url, auth, page: 2)
+
+    expect { resource.wadus }.to raise_error{ |error|
+      expect(error).to be_a(Almodovar::HttpError)
+      expect(error.message).to eq(error_message(400, resource_url, { page: 2 }))
+      expect(error.response_body).to eq('<error>more info</error>')
+    }
+  end
+
   private
 
-  def error_message(code, url)
-    "Status code #{code} on resource #{url}"
+  def error_message(code, url, query_params = {})
+    message = "Status code #{code} on resource #{url}"
+    message += " with params: #{query_params.inspect}" if query_params.any?
+    message
   end
 end

--- a/spec/acceptance/errors_spec.rb
+++ b/spec/acceptance/errors_spec.rb
@@ -7,7 +7,7 @@ describe "Errors should raise exceptions" do
 
   %w{400 401 403 404 405 406 422 500 502 503}.each do |code|
     example "Receiving #{code} in a GET request" do
-      stub_auth_request(:get, resource_url).to_return(:body => '<error>more info</error>', :status => code.to_i)
+      stub_auth_request(:get, resource_url).to_return(body: '<error>more info</error>', status: code.to_i)
 
       resource = Almodovar::Resource(resource_url, auth)
 
@@ -19,11 +19,11 @@ describe "Errors should raise exceptions" do
     end
 
     example "Receiving #{code} in a POST request" do
-      stub_auth_request(:post, resources_url).to_return(:body => '<error>more info</error>', :status => code.to_i)
+      stub_auth_request(:post, resources_url).to_return(body: '<error>more info</error>', status: code.to_i)
 
       resources = Almodovar::Resource(resources_url, auth)
 
-      expect { resources.create(:resource => {:wadus => 'wadus'}) }.to raise_error{ |error|
+      expect { resources.create(resource: {wadus: 'wadus'}) }.to raise_error{ |error|
         expect(error).to be_a(Almodovar::HttpError)
         expect(error.message).to eq(error_message(code, resources_url))
         expect(error.response_body).to eq('<error>more info</error>')
@@ -31,11 +31,11 @@ describe "Errors should raise exceptions" do
     end
 
     example "Receiving #{code} in a PUT request" do
-      stub_auth_request(:put, resource_url).to_return(:body => '<error>more info</error>', :status => code.to_i)
+      stub_auth_request(:put, resource_url).to_return(body: '<error>more info</error>', status: code.to_i)
 
       resource = Almodovar::Resource(resource_url, auth)
 
-      expect { resource.update(:resource => {:wadus => 'wadus'}) }.to raise_error{ |error|
+      expect { resource.update(resource: {wadus: 'wadus'}) }.to raise_error{ |error|
         expect(error).to be_a(Almodovar::HttpError)
         expect(error.message).to eq(error_message(code, resource_url))
         expect(error.response_body).to eq('<error>more info</error>')
@@ -43,7 +43,7 @@ describe "Errors should raise exceptions" do
     end
 
     example "Receiving #{code} in a DELETE request" do
-      stub_auth_request(:delete, resource_url).to_return(:body => '<error>more info</error>', :status => code.to_i)
+      stub_auth_request(:delete, resource_url).to_return(body: '<error>more info</error>', status: code.to_i)
 
       resource = Almodovar::Resource(resource_url, auth)
 

--- a/spec/acceptance/fetch_paginated_resource_collections_spec.rb
+++ b/spec/acceptance/fetch_paginated_resource_collections_spec.rb
@@ -19,10 +19,10 @@ describe "Fetching paginated resource collections" do
     })
     
     resources = Almodovar::Resource("http://movida.example.com/resources", auth)
-    resources.total_entries.should == 4
-    resources.size.should == 2
-    resources.map(&:name).should == ["Resource 1", "Resource 2"]
-    resources.next_url.should == "http://movida.example.com/resources?page=2"
+    expect(resources.total_entries).to eq(4)
+    expect(resources.size).to eq(2)
+    expect(resources.map(&:name)).to eq(["Resource 1", "Resource 2"])
+    expect(resources.next_url).to eq("http://movida.example.com/resources?page=2")
   end
 
   example "Navigate through collection pages" do
@@ -58,22 +58,22 @@ describe "Fetching paginated resource collections" do
     
     resources = Almodovar::Resource("http://movida.example.com/resources", auth)
     
-    resources.map(&:name).should == ["Resource 1", "Resource 2"]
-    resources.next_url.should == "http://movida.example.com/resources?page=2"
-    resources.prev_url.should be_nil
+    expect(resources.map(&:name)).to eq(["Resource 1", "Resource 2"])
+    expect(resources.next_url).to eq("http://movida.example.com/resources?page=2")
+    expect(resources.prev_url).to be_nil
     resources = resources.next_page
 
-    resources.map(&:name).should == ["Resource 3", "Resource 4"]
-    resources.size.should == 2
-    resources.total_entries.should == 4
-    resources.prev_url.should == "http://movida.example.com/resources"
-    resources.next_url.should be_nil
+    expect(resources.map(&:name)).to eq(["Resource 3", "Resource 4"])
+    expect(resources.size).to eq(2)
+    expect(resources.total_entries).to eq(4)
+    expect(resources.prev_url).to eq("http://movida.example.com/resources")
+    expect(resources.next_url).to be_nil
 
     resources = resources.prev_page
 
-    resources.map(&:name).should == ["Resource 1", "Resource 2"]
-    resources.size.should == 2
-    resources.total_entries.should == 4
+    expect(resources.map(&:name)).to eq(["Resource 1", "Resource 2"])
+    expect(resources.size).to eq(2)
+    expect(resources.total_entries).to eq(4)
   end
 
   example "Fetch empty collection" do
@@ -85,12 +85,12 @@ describe "Fetching paginated resource collections" do
     
     resources = Almodovar::Resource("http://movida.example.com/resources", auth)
     
-    resources.size.should == 0
-    resources.total_entries.should == 0
-    resources.next_url.should be_nil
-    resources.prev_url.should be_nil
-    resources.next_page.should be_nil
-    resources.prev_page.should be_nil
+    expect(resources.size).to eq(0)
+    expect(resources.total_entries).to eq(0)
+    expect(resources.next_url).to be_nil
+    expect(resources.prev_url).to be_nil
+    expect(resources.next_page).to be_nil
+    expect(resources.prev_page).to be_nil
   end
 
 end

--- a/spec/acceptance/fetch_paginated_resource_collections_spec.rb
+++ b/spec/acceptance/fetch_paginated_resource_collections_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Fetching paginated resource collections" do
   
   example "Fetch collection" do
-    stub_auth_request(:get, "http://movida.example.com/resources").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resources").to_return(body: %q{
       <resources type='array'>
         <total-entries>4</total-entries>
         <link rel='next' href='http://movida.example.com/resources?page=2'/>
@@ -26,7 +26,7 @@ describe "Fetching paginated resource collections" do
   end
 
   example "Navigate through collection pages" do
-    stub_auth_request(:get, "http://movida.example.com/resources").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resources").to_return(body: %q{
       <resources type='array'>
         <total-entries>4</total-entries>
         <link rel='next' href='http://movida.example.com/resources?page=2'/>
@@ -41,7 +41,7 @@ describe "Fetching paginated resource collections" do
       </resources>
     })
 
-    stub_auth_request(:get, "http://movida.example.com/resources?page=2").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resources?page=2").to_return(body: %q{
       <resources type='array'>
         <total-entries>4</total-entries>
         <link rel='prev' href='http://movida.example.com/resources'/>
@@ -77,7 +77,7 @@ describe "Fetching paginated resource collections" do
   end
 
   example "Fetch empty collection" do
-    stub_auth_request(:get, "http://movida.example.com/resources").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resources").to_return(body: %q{
       <resources type='array'>
         <total-entries>0</total-entries>
       </resources>

--- a/spec/acceptance/fetch_resource_collections_spec.rb
+++ b/spec/acceptance/fetch_resource_collections_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Fetching resource collections" do
 
   example "Fetch collection" do
-    stub_auth_request(:get, "http://movida.example.com/resources").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resources").to_return(body: %q{
       <resources type='array'>
         <resource>
           <link rel='self' href='http://movida.example.com/resources/1'/>
@@ -25,7 +25,7 @@ describe "Fetching resource collections" do
   end
 
   example "Fetch a collection with params" do
-    stub_auth_request(:get, "http://movida.example.com/resources?name=Jon%20Snow").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resources?name=Jon%20Snow").to_return(body: %q{
       <resources type='array'>
         <resource>
           <name>Jon Snow</name>
@@ -33,14 +33,14 @@ describe "Fetching resource collections" do
       </resources>
     })
 
-    resources = Almodovar::Resource("http://movida.example.com/resources", auth, :name => "Jon Snow")
+    resources = Almodovar::Resource("http://movida.example.com/resources", auth, name: "Jon Snow")
 
     expect(resources.size).to eq(1)
     expect(resources.first.name).to eq("Jon Snow")
   end
 
   example "Fetch a collection with params unescaped in the url" do
-    stub_auth_request(:get, "http://movida.example.com/resources?name=Jon%20Snow").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resources?name=Jon%20Snow").to_return(body: %q{
       <resources type='array'>
         <resource>
           <name>Jon Snow</name>
@@ -55,7 +55,7 @@ describe "Fetching resource collections" do
   end
 
   example "Fetch a collection with params escaped in the url" do
-    stub_auth_request(:get, "http://movida.example.com/resources?name=Jon%20Snow").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resources?name=Jon%20Snow").to_return(body: %q{
       <resources type='array'>
         <resource>
           <name>Jon Snow</name>
@@ -70,7 +70,7 @@ describe "Fetching resource collections" do
   end
 
   example "Inspecting a collection" do
-    stub_auth_request(:get, "http://movida.example.com/resources").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resources").to_return(body: %q{
       <resources type='array'>
         <resource>
           <name>Pedro</name>
@@ -84,7 +84,7 @@ describe "Fetching resource collections" do
   end
 
   example "Selecting elements from a collection" do
-    stub_auth_request(:get, "http://movida.example.com/resources").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resources").to_return(body: %q{
       <resources type='array'>
         <resource>
           <link rel='self' href='http://movida.example.com/resources/1'/>
@@ -106,7 +106,7 @@ describe "Fetching resource collections" do
   end
 
   example "Pagination methods on non paginated collection" do
-    stub_auth_request(:get, "http://movida.example.com/resources").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resources").to_return(body: %q{
       <resources type='array'>
         <resource>
           <link rel='self' href='http://movida.example.com/resources/1'/>

--- a/spec/acceptance/fetch_resource_collections_spec.rb
+++ b/spec/acceptance/fetch_resource_collections_spec.rb
@@ -18,10 +18,10 @@ describe "Fetching resource collections" do
 
     resources = Almodovar::Resource("http://movida.example.com/resources", auth)
 
-    resources.map(&:name).should == ["Resource 1", "Resource 2"]
-    resources.size.should == 2
-    resources.first.name.should == "Resource 1"
-    resources.last.name.should  == "Resource 2"
+    expect(resources.map(&:name)).to eq(["Resource 1", "Resource 2"])
+    expect(resources.size).to eq(2)
+    expect(resources.first.name).to eq("Resource 1")
+    expect(resources.last.name).to  eq("Resource 2")
   end
 
   example "Fetch a collection with params" do
@@ -35,8 +35,8 @@ describe "Fetching resource collections" do
 
     resources = Almodovar::Resource("http://movida.example.com/resources", auth, :name => "Jon Snow")
 
-    resources.size.should == 1
-    resources.first.name.should == "Jon Snow"
+    expect(resources.size).to eq(1)
+    expect(resources.first.name).to eq("Jon Snow")
   end
 
   example "Fetch a collection with params unescaped in the url" do
@@ -50,8 +50,8 @@ describe "Fetching resource collections" do
 
     resources = Almodovar::Resource("http://movida.example.com/resources?name=Jon Snow", auth)
 
-    resources.size.should == 1
-    resources.first.name.should == "Jon Snow"
+    expect(resources.size).to eq(1)
+    expect(resources.first.name).to eq("Jon Snow")
   end
 
   example "Fetch a collection with params escaped in the url" do
@@ -65,8 +65,8 @@ describe "Fetching resource collections" do
 
     resources = Almodovar::Resource("http://movida.example.com/resources?name=Jon%20Snow", auth)
 
-    resources.size.should == 1
-    resources.first.name.should == "Jon Snow"
+    expect(resources.size).to eq(1)
+    expect(resources.first.name).to eq("Jon Snow")
   end
 
   example "Inspecting a collection" do
@@ -80,7 +80,7 @@ describe "Fetching resource collections" do
 
     resources = Almodovar::Resource("http://movida.example.com/resources", auth)
 
-    resources.inspect.should == "[#{resources.first.inspect}]"
+    expect(resources.inspect).to eq("[#{resources.first.inspect}]")
   end
 
   example "Selecting elements from a collection" do
@@ -98,11 +98,11 @@ describe "Fetching resource collections" do
     })
 
     resources = Almodovar::Resource("http://movida.example.com/resources", auth)
-    resources.size.should == 2
+    expect(resources.size).to eq(2)
 
     selected = resources.select {|r| r.name == "Resource 1"}
-    selected.size.should == 1
-    selected.first.name.should == "Resource 1"
+    expect(selected.size).to eq(1)
+    expect(selected.first.name).to eq("Resource 1")
   end
 
   example "Pagination methods on non paginated collection" do
@@ -120,10 +120,10 @@ describe "Fetching resource collections" do
     })
 
     resources = Almodovar::Resource("http://movida.example.com/resources", auth)
-    resources.total_entries.should == 2
-    resources.size.should == 2
-    resources.next_url.should be_nil
-    resources.prev_url.should be_nil
+    expect(resources.total_entries).to eq(2)
+    expect(resources.size).to eq(2)
+    expect(resources.next_url).to be_nil
+    expect(resources.prev_url).to be_nil
   end
 
 end

--- a/spec/acceptance/fetch_resource_collections_spec.rb
+++ b/spec/acceptance/fetch_resource_collections_spec.rb
@@ -40,18 +40,20 @@ describe "Fetching resource collections" do
   end
 
   example "Fetch a collection with params unescaped in the url" do
-    stub_auth_request(:get, "http://movida.example.com/resources?name=Jon%20Snow").to_return(body: %q{
+    stub_auth_request(:get, "http://movida.example.com/resources?name=Jon%20Snow&parents=Eddard%20%26%20Lyanna%20Stark").to_return(body: %q{
       <resources type='array'>
         <resource>
           <name>Jon Snow</name>
+          <parents>Eddard &amp; Lyanna Stark</parents>
         </resource>
       </resources>
     })
 
-    resources = Almodovar::Resource("http://movida.example.com/resources?name=Jon Snow", auth)
+    resources = Almodovar::Resource("http://movida.example.com/resources", auth, name: "Jon Snow", parents: "Eddard & Lyanna Stark")
 
     expect(resources.size).to eq(1)
     expect(resources.first.name).to eq("Jon Snow")
+    expect(resources.first.parents).to eq("Eddard & Lyanna Stark")
   end
 
   example "Fetch a collection with params escaped in the url" do

--- a/spec/acceptance/fetch_single_resources_spec.rb
+++ b/spec/acceptance/fetch_single_resources_spec.rb
@@ -12,9 +12,9 @@ describe "Fetching individual resources" do
     })
     
     resource = Almodovar::Resource("http://movida.example.com/resource", auth)
-    resource.name.should == "Resource Name"
-    resource.res_id.should == "12345"
-    resource.creation_date.should == "2009-01-01T10:00:00Z"
+    expect(resource.name).to eq("Resource Name")
+    expect(resource.res_id).to eq("12345")
+    expect(resource.creation_date).to eq("2009-01-01T10:00:00Z")
     
     expect { resource.wadus }.to raise_error(NoMethodError)
   end
@@ -31,16 +31,16 @@ describe "Fetching individual resources" do
     
     resource = Almodovar::Resource("http://movida.example.com/resource", auth)
 
-    resource.should respond_to(:id)
-    resource.should respond_to(:date)
-    resource.should respond_to(:type)
-    resource.should respond_to(:expire_at)
-    resource.should_not respond_to(:wadus)
+    expect(resource).to respond_to(:id)
+    expect(resource).to respond_to(:date)
+    expect(resource).to respond_to(:type)
+    expect(resource).to respond_to(:expire_at)
+    expect(resource).not_to respond_to(:wadus)
     
-    resource.id.should == 12345
-    resource.date.should == Time.utc(2009,1,1,10,0,0)
-    resource.type.should == "wadus"
-    resource.expire_at.should == Date.parse('2009-1-1')
+    expect(resource.id).to eq(12345)
+    expect(resource.date).to eq(Time.utc(2009,1,1,10,0,0))
+    expect(resource.type).to eq("wadus")
+    expect(resource.expire_at).to eq(Date.parse('2009-1-1'))
   end
 
   example "Fetching typed attributes: array" do
@@ -55,13 +55,13 @@ describe "Fetching individual resources" do
 
     resource = Almodovar::Resource("http://movida.example.com/resource", auth)
 
-    resource.should respond_to(:'cue-points')
-    resource.should_not respond_to(:wadus)
+    expect(resource).to respond_to(:'cue-points')
+    expect(resource).not_to respond_to(:wadus)
 
-    resource.cue_points.should == ["00:07:00", "00:14:00"]
-    resource.cue_points[0].should == "00:07:00"
-    resource.cue_points[1].should == "00:14:00"
-    resource.cue_points.length.should == 2
+    expect(resource.cue_points).to eq(["00:07:00", "00:14:00"])
+    expect(resource.cue_points[0]).to eq("00:07:00")
+    expect(resource.cue_points[1]).to eq("00:14:00")
+    expect(resource.cue_points.length).to eq(2)
   end
 
   example "Inspecting a resource" do
@@ -75,7 +75,7 @@ describe "Fetching individual resources" do
     
     resource = Almodovar::Resource("http://movida.example.com/resource", auth)
 
-    Nokogiri::XML.parse(resource.inspect).to_xml.should == Nokogiri::XML.parse(xml).to_xml
+    expect(Nokogiri::XML.parse(resource.inspect).to_xml).to eq(Nokogiri::XML.parse(xml).to_xml)
   end
   
   example "Using a port different than default" do
@@ -86,7 +86,7 @@ describe "Fetching individual resources" do
     })
     
     resource = Almodovar::Resource("http://movida.example.com:3000/resource", auth)
-    resource.name.should == "Resource Name"
+    expect(resource.name).to eq("Resource Name")
   end
   
 end

--- a/spec/acceptance/fetch_single_resources_spec.rb
+++ b/spec/acceptance/fetch_single_resources_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe "Fetching individual resources" do  
 
   example "Fetching untyped attributes" do
-    stub_auth_request(:get, "http://movida.example.com/resource").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resource").to_return(body: %q{
       <resource>
         <name>Resource Name</name>
         <res_id>12345</res_id>
@@ -20,7 +20,7 @@ describe "Fetching individual resources" do
   end
   
   example "Fetching typed attributes" do
-    stub_auth_request(:get, "http://movida.example.com/resource").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resource").to_return(body: %q{
       <resource>
         <id type="integer">12345</id>
         <date type="datetime">2009-01-01T10:00:00Z</date>
@@ -44,7 +44,7 @@ describe "Fetching individual resources" do
   end
 
   example "Fetching typed attributes: array" do
-    stub_auth_request(:get, "http://movida.example.com/resource").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/resource").to_return(body: %q{
       <resource>
         <cue-points type="array">
           <cue-point>00:07:00</cue-point>
@@ -71,7 +71,7 @@ describe "Fetching individual resources" do
         <date type="datetime">2009-01-01T10:00:00Z</date>
       </resource>      
     }
-    stub_auth_request(:get, "http://movida.example.com/resource").to_return(:body => xml)
+    stub_auth_request(:get, "http://movida.example.com/resource").to_return(body: xml)
     
     resource = Almodovar::Resource("http://movida.example.com/resource", auth)
 
@@ -79,7 +79,7 @@ describe "Fetching individual resources" do
   end
   
   example "Using a port different than default" do
-    stub_auth_request(:get, "http://movida.example.com:3000/resource").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com:3000/resource").to_return(body: %q{
       <resource>
         <name>Resource Name</name>
       </resource>

--- a/spec/acceptance/from_xml_spec.rb
+++ b/spec/acceptance/from_xml_spec.rb
@@ -17,8 +17,8 @@ describe "Instantiate resources from xml" do
     }
     project = Almodovar::Resource.from_xml(xml)
     
-    project.name.should == "My cool project"
-    project.tasks.first.name.should == "Start project"
+    expect(project.name).to eq("My cool project")
+    expect(project.tasks.first.name).to eq("Start project")
   end
   
   it "should make further HTTP calls if needed" do
@@ -30,7 +30,7 @@ describe "Instantiate resources from xml" do
     }
     project = Almodovar::Resource.from_xml(xml, auth)
     
-    project.name.should == "My cool project"
+    expect(project.name).to eq("My cool project")
     
     stub_auth_request(:get, "http://example.com/p/1/t?expand=responsible").to_return(:body => %q{
       <tasks type="array">
@@ -47,7 +47,7 @@ describe "Instantiate resources from xml" do
     
     tasks = project.tasks(:expand => "responsible")
     
-    tasks.first.name.should == "Start project"
+    expect(tasks.first.name).to eq("Start project")
     tasks.first.responsible.name == "El Fary"
   end
   

--- a/spec/acceptance/from_xml_spec.rb
+++ b/spec/acceptance/from_xml_spec.rb
@@ -32,7 +32,7 @@ describe "Instantiate resources from xml" do
     
     expect(project.name).to eq("My cool project")
     
-    stub_auth_request(:get, "http://example.com/p/1/t?expand=responsible").to_return(:body => %q{
+    stub_auth_request(:get, "http://example.com/p/1/t?expand=responsible").to_return(body: %q{
       <tasks type="array">
         <task>
           <name>Start project</name>
@@ -45,7 +45,7 @@ describe "Instantiate resources from xml" do
       </tasks>      
     })
     
-    tasks = project.tasks(:expand => "responsible")
+    tasks = project.tasks(expand: "responsible")
     
     expect(tasks.first.name).to eq("Start project")
     tasks.first.responsible.name == "El Fary"

--- a/spec/acceptance/navigate_documents_spec.rb
+++ b/spec/acceptance/navigate_documents_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe "Navigating included documents" do
   
   example "Accesing included data" do
-    stub_auth_request(:get, "http://movida.example.com/people/1").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/people/1").to_return(body: %q{
       <person>
         <name>Pedro Almodóvar</name>
         <extra-data type="document">
@@ -56,7 +56,7 @@ describe "Navigating included documents" do
   end
   
   example "Accessing document resources" do
-    stub_auth_request(:get, "http://movida.example.com/people/1/biography").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/people/1/biography").to_return(body: %q{
       <biography type="document">
         <birthplace>Calzada de Calatrava</birthplace>
         <birthyear type="integer">1949</birthyear>

--- a/spec/acceptance/navigate_documents_spec.rb
+++ b/spec/acceptance/navigate_documents_spec.rb
@@ -39,19 +39,19 @@ describe "Navigating included documents" do
   
     person = Almodovar::Resource("http://movida.example.com/people/1", auth)
     
-    person.should respond_to(:extra_data)
+    expect(person).to respond_to(:extra_data)
     
-    person.name.should == "Pedro Almodóvar"
-    person.extra_data["biography"]["birthplace"].should == "Calzada de Calatrava"
-    person.extra_data["biography"]["birthyear"].should == 1949
-    person.extra_data["biography"]["films"][0]["title"].should == "¿Qué he hecho yo para merecer esto?"
-    person.extra_data["biography"]["films"][0]["year"].should == 1984
-    person.extra_data["biography"]["films"][1]["title"].should == "Mujeres al borde de un ataque de nervios"
-    person.extra_data["biography"]["films"][1]["year"].should == 1988
-    person.extra_data["oscars"][0]["year"].should == 1999
-    person.extra_data["oscars"][0]["film"].should == "Todo sobre mi madre"
-    person.extra_data["oscars"][1]["year"].should == 2002
-    person.extra_data["oscars"][1]["film"].should == "Hable con ella"
+    expect(person.name).to eq("Pedro Almodóvar")
+    expect(person.extra_data["biography"]["birthplace"]).to eq("Calzada de Calatrava")
+    expect(person.extra_data["biography"]["birthyear"]).to eq(1949)
+    expect(person.extra_data["biography"]["films"][0]["title"]).to eq("¿Qué he hecho yo para merecer esto?")
+    expect(person.extra_data["biography"]["films"][0]["year"]).to eq(1984)
+    expect(person.extra_data["biography"]["films"][1]["title"]).to eq("Mujeres al borde de un ataque de nervios")
+    expect(person.extra_data["biography"]["films"][1]["year"]).to eq(1988)
+    expect(person.extra_data["oscars"][0]["year"]).to eq(1999)
+    expect(person.extra_data["oscars"][0]["film"]).to eq("Todo sobre mi madre")
+    expect(person.extra_data["oscars"][1]["year"]).to eq(2002)
+    expect(person.extra_data["oscars"][1]["film"]).to eq("Hable con ella")
     
   end
   
@@ -75,12 +75,12 @@ describe "Navigating included documents" do
   
     bio = Almodovar::Resource("http://movida.example.com/people/1/biography", auth)
     
-    bio["birthplace"].should == "Calzada de Calatrava"
-    bio["birthyear"].should == 1949
-    bio["films"][0]["title"].should == "¿Qué he hecho yo para merecer esto?"
-    bio["films"][0]["year"].should == 1984
-    bio["films"][1]["title"].should == "Mujeres al borde de un ataque de nervios"
-    bio["films"][1]["year"].should == 1988
+    expect(bio["birthplace"]).to eq("Calzada de Calatrava")
+    expect(bio["birthyear"]).to eq(1949)
+    expect(bio["films"][0]["title"]).to eq("¿Qué he hecho yo para merecer esto?")
+    expect(bio["films"][0]["year"]).to eq(1984)
+    expect(bio["films"][1]["title"]).to eq("Mujeres al borde de un ataque de nervios")
+    expect(bio["films"][1]["year"]).to eq(1988)
   end
   
 end

--- a/spec/acceptance/navigate_linked_resources_spec.rb
+++ b/spec/acceptance/navigate_linked_resources_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Navigating linked resources" do
   example "Link to a single resource" do
-    stub_auth_request(:get, "http://movida.example.com/user/1").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/user/1").to_return(body: %q{
       <user>
         <link rel="related-company" href="http://movida.example.com/company/2"/>
       </user>
@@ -10,7 +10,7 @@ describe "Navigating linked resources" do
     
     user = Almodovar::Resource("http://movida.example.com/user/1", auth)
     
-    stub_auth_request(:get, "http://movida.example.com/company/2").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/company/2").to_return(body: %q{
       <company>
         <age type="integer">15</age>
       </company>
@@ -23,7 +23,7 @@ describe "Navigating linked resources" do
   end
   
   example "Link to a collection of resources" do
-    stub_auth_request(:get, "http://movida.example.com/company/1").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/company/1").to_return(body: %q{
       <company>
         <link rel="related_users" href="http://movida.example.com/company/1/users"/>
       </company>
@@ -31,7 +31,7 @@ describe "Navigating linked resources" do
     
     company = Almodovar::Resource("http://movida.example.com/company/1", auth)
     
-    stub_auth_request(:get, "http://movida.example.com/company/1/users").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/company/1/users").to_return(body: %q{
       <users type="array">
         <user>
           <age type="integer">46</age>
@@ -50,7 +50,7 @@ describe "Navigating linked resources" do
   end
   
   example "Link to a collection of resources with params" do
-    stub_auth_request(:get, "http://movida.example.com/company/1").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/company/1").to_return(body: %q{
       <company>
         <link rel="related_users" href="http://movida.example.com/company/1/users"/>
       </company>
@@ -58,7 +58,7 @@ describe "Navigating linked resources" do
     
     company = Almodovar::Resource("http://movida.example.com/company/1", auth)
     
-    stub_auth_request(:get, "http://movida.example.com/company/1/users?min_age=23&recent=true").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/company/1/users?min_age=23&recent=true").to_return(body: %q{
       <users type="array">
         <user>
           <age type="integer">46</age>
@@ -69,11 +69,11 @@ describe "Navigating linked resources" do
       </users>
     })
     
-    expect(company.related_users(:min_age => 23, :recent => true).size).to eq(2)
+    expect(company.related_users(min_age: 23, recent: true).size).to eq(2)
   end
   
   example "Expanded link to a single resource" do
-    stub_auth_request(:get, "http://movida.example.com/user/1?expand=employer").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/user/1?expand=employer").to_return(body: %q{
       <user>
         <link rel="employer" href="http://movida.example.com/company/2">
           <company>
@@ -83,7 +83,7 @@ describe "Navigating linked resources" do
       </user>
     })
     
-    user = Almodovar::Resource("http://movida.example.com/user/1", auth, :expand => :employer)
+    user = Almodovar::Resource("http://movida.example.com/user/1", auth, expand: :employer)
     
     expect(user.employer).not_to be_nil
     expect(user.employer.age).to eq(15)
@@ -91,7 +91,7 @@ describe "Navigating linked resources" do
   
   example "Expanded link to a resource collection" do
     
-    stub_auth_request(:get, "http://movida.example.com/company/1?expand=users,department").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/company/1?expand=users,department").to_return(body: %q{
       <company>
         <link rel="users" href="http://movida.example.com/company/1/users">
           <users type="array">
@@ -114,7 +114,7 @@ describe "Navigating linked resources" do
       </company>
     })
     
-    company = Almodovar::Resource("http://movida.example.com/company/1", auth, :expand => [:users, :department])
+    company = Almodovar::Resource("http://movida.example.com/company/1", auth, expand: [:users, :department])
     
     expect(company.users.size).to eq(2)
     expect(company.users.first.department.name).to eq("Sales")
@@ -123,7 +123,7 @@ describe "Navigating linked resources" do
   end
   
   example "Expanded link to a resource collection using params" do
-    stub_auth_request(:get, "http://movida.example.com/company/1?expand=users").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/company/1?expand=users").to_return(body: %q{
       <company>
         <link rel="users" href="http://movida.example.com/company/1/users">
           <users type="array">
@@ -138,9 +138,9 @@ describe "Navigating linked resources" do
       </company>
     })
     
-    company = Almodovar::Resource("http://movida.example.com/company/1", auth, :expand => :users)
+    company = Almodovar::Resource("http://movida.example.com/company/1", auth, expand: :users)
     
-    stub_auth_request(:get, "http://movida.example.com/company/1/users?min_age=40").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/company/1/users?min_age=40").to_return(body: %q{
       <users type="array">
         <user>
           <age type="integer">46</age>
@@ -148,11 +148,11 @@ describe "Navigating linked resources" do
       </users>
     })
     
-    expect(company.users(:min_age => 40).size).to eq(1)
+    expect(company.users(min_age: 40).size).to eq(1)
   end
 
   example "Link to self" do
-    stub_auth_request(:get, "http://movida.example.com/user/1").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com/user/1").to_return(body: %q{
       <user>
         <link rel="self" href="http://movida.example.com/user/1"/>
       </user>
@@ -164,7 +164,7 @@ describe "Navigating linked resources" do
   end
   
   example "Using a port different than default" do
-    stub_auth_request(:get, "http://movida.example.com:3000/user/1").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com:3000/user/1").to_return(body: %q{
       <user>
         <link rel="related-company" href="http://movida.example.com:3000/company/2"/>
       </user>
@@ -172,7 +172,7 @@ describe "Navigating linked resources" do
     
     user = Almodovar::Resource("http://movida.example.com:3000/user/1", auth)
     
-    stub_auth_request(:get, "http://movida.example.com:3000/company/2").to_return(:body => %q{
+    stub_auth_request(:get, "http://movida.example.com:3000/company/2").to_return(body: %q{
       <company>
         <age type="integer">15</age>
       </company>

--- a/spec/acceptance/navigate_linked_resources_spec.rb
+++ b/spec/acceptance/navigate_linked_resources_spec.rb
@@ -16,10 +16,10 @@ describe "Navigating linked resources" do
       </company>
     })
     
-    user.should respond_to(:related_company)
+    expect(user).to respond_to(:related_company)
     
-    user.related_company.should_not be_nil
-    user.related_company.age.should == 15
+    expect(user.related_company).not_to be_nil
+    expect(user.related_company.age).to eq(15)
   end
   
   example "Link to a collection of resources" do
@@ -42,11 +42,11 @@ describe "Navigating linked resources" do
       </users>
     })
     
-    company.should respond_to(:related_users)
+    expect(company).to respond_to(:related_users)
     
-    company.related_users.size.should == 2
-    company.related_users.first.age.should == 46
-    company.related_users.last.age.should == 33
+    expect(company.related_users.size).to eq(2)
+    expect(company.related_users.first.age).to eq(46)
+    expect(company.related_users.last.age).to eq(33)
   end
   
   example "Link to a collection of resources with params" do
@@ -69,7 +69,7 @@ describe "Navigating linked resources" do
       </users>
     })
     
-    company.related_users(:min_age => 23, :recent => true).size.should == 2
+    expect(company.related_users(:min_age => 23, :recent => true).size).to eq(2)
   end
   
   example "Expanded link to a single resource" do
@@ -85,8 +85,8 @@ describe "Navigating linked resources" do
     
     user = Almodovar::Resource("http://movida.example.com/user/1", auth, :expand => :employer)
     
-    user.employer.should_not be_nil
-    user.employer.age.should == 15
+    expect(user.employer).not_to be_nil
+    expect(user.employer.age).to eq(15)
   end
   
   example "Expanded link to a resource collection" do
@@ -116,9 +116,9 @@ describe "Navigating linked resources" do
     
     company = Almodovar::Resource("http://movida.example.com/company/1", auth, :expand => [:users, :department])
     
-    company.users.size.should == 2
-    company.users.first.department.name.should == "Sales"
-    company.users.last.department.name.should == "Development"
+    expect(company.users.size).to eq(2)
+    expect(company.users.first.department.name).to eq("Sales")
+    expect(company.users.last.department.name).to eq("Development")
     
   end
   
@@ -148,7 +148,7 @@ describe "Navigating linked resources" do
       </users>
     })
     
-    company.users(:min_age => 40).size.should == 1
+    expect(company.users(:min_age => 40).size).to eq(1)
   end
 
   example "Link to self" do
@@ -160,7 +160,7 @@ describe "Navigating linked resources" do
     
     user = Almodovar::Resource("http://movida.example.com/user/1", auth)
     
-    user.url.should == "http://movida.example.com/user/1"
+    expect(user.url).to eq("http://movida.example.com/user/1")
   end
   
   example "Using a port different than default" do
@@ -178,7 +178,7 @@ describe "Navigating linked resources" do
       </company>
     })
     
-    user.related_company.should_not be_nil
-    user.related_company.age.should == 15
+    expect(user.related_company).not_to be_nil
+    expect(user.related_company.age).to eq(15)
   end
 end

--- a/spec/acceptance/timeout_spec.rb
+++ b/spec/acceptance/timeout_spec.rb
@@ -22,7 +22,7 @@ describe "Timeout" do
         stub_auth_request(:post, "http://movida.example.com/projects").to_raise(httpclient_exception)
 
         expect {
-          projects.create(project: { name: "Wadus"})
+          projects.create(project: { name: "Wadus" })
         }.to raise_error(almodovar_exception)
       end
 
@@ -32,7 +32,7 @@ describe "Timeout" do
         stub_auth_request(:put, "http://movida.example.com/projects/1").to_raise(httpclient_exception)
 
         expect {
-          projects.update(project: { name: "Wadus"})
+          projects.update(project: { name: "Wadus" })
         }.to raise_error(almodovar_exception)
       end
 

--- a/spec/acceptance/update_resource_spec.rb
+++ b/spec/acceptance/update_resource_spec.rb
@@ -16,7 +16,7 @@ describe "Updating resources" do
     
     project.update(:project => {:name => "Wadus Wadus"})
     
-    project.name.should == "Wadus Wadus"
+    expect(project.name).to eq("Wadus Wadus")
   end
   
   example "Updating a document resource" do
@@ -31,7 +31,7 @@ describe "Updating resources" do
     
     extra_data = Almodovar::Resource("http://movida.example.com/people/1/extra_data", auth)
     extra_data.update(:extra_data => {:birthplace => "Calzada de Calatrava"})
-    extra_data.birthplace.should == "Calzada de Calatrava"
+    expect(extra_data.birthplace).to eq("Calzada de Calatrava")
   end
   
 end

--- a/spec/acceptance/update_resource_spec.rb
+++ b/spec/acceptance/update_resource_spec.rb
@@ -4,8 +4,8 @@ describe "Updating resources" do
   
   example "Updating a resource" do
     stub_auth_request(:put, "http://movida.example.com/projects/1").with do |req|
-      req.body == {:name => "Wadus Wadus"}.to_xml(:root => "project")
-    end.to_return(:body => <<-XML)
+      req.body == {name: "Wadus Wadus"}.to_xml(root: "project")
+    end.to_return(body: <<-XML)
       <project>
         <name>Wadus Wadus</name>
         <link rel="self" href="http://movida.example.com/projects/1"/>
@@ -14,15 +14,15 @@ describe "Updating resources" do
     
     project = Almodovar::Resource("http://movida.example.com/projects/1", auth)
     
-    project.update(:project => {:name => "Wadus Wadus"})
+    project.update(project: {name: "Wadus Wadus"})
     
     expect(project.name).to eq("Wadus Wadus")
   end
   
   example "Updating a document resource" do
     stub_auth_request(:put, "http://movida.example.com/people/1/extra_data").with do |req|
-      req.body == {:birthplace => "Calzada de Calatrava"}.to_xml(:root => "extra-data")
-    end.to_return(:body => <<-XML)
+      req.body == {birthplace: "Calzada de Calatrava"}.to_xml(root: "extra-data")
+    end.to_return(body: <<-XML)
       <extra-data type="document">
         <birthplace>Calzada de Calatrava</birthplace>
         <birthyear type="integer">1949</birthyear>
@@ -30,7 +30,7 @@ describe "Updating resources" do
     XML
     
     extra_data = Almodovar::Resource("http://movida.example.com/people/1/extra_data", auth)
-    extra_data.update(:extra_data => {:birthplace => "Calzada de Calatrava"})
+    extra_data.update(extra_data: {birthplace: "Calzada de Calatrava"})
     expect(extra_data.birthplace).to eq("Calzada de Calatrava")
   end
   

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,7 +45,7 @@ module NokogiriMatchers
       xml_string.starts_with?(processing_instruction)
     end
 
-    failure_message_for_should do |xml_string|
+    failure_message do |xml_string|
       "expected to have #{processing_instruction} at the beggining of xml:\n#{xml_string}"
     end
   end
@@ -55,11 +55,11 @@ module NokogiriMatchers
       Nokogiri::XML.parse(xml_string).at_xpath(xpath) != nil
     end
 
-    failure_message_for_should do |xml_string|
+    failure_message do |xml_string|
       "expected to match xpath #{xpath} in xml:\n#{xml_string}"
     end
 
-    failure_message_for_should_not do |xml_string|
+    failure_message_when_negated do |xml_string|
       "expected to not match xpath #{xpath} in xml:\n#{xml_string}"
     end
 
@@ -72,11 +72,11 @@ module NokogiriMatchers
       Lorax::Signature.new(@expected_doc.root).signature == Lorax::Signature.new(@actual_doc.root).signature
     end
 
-    failure_message_for_should do |actual_xml_string|
+    failure_message do |actual_xml_string|
       "XML documents expected to be the same:\n\nExpected:\n#{expected_xml_string}\n\nActual:\n#{actual_xml_string}"
     end
 
-    failure_message_for_should_not do |actual_xml_string|
+    failure_message_when_negated do |actual_xml_string|
       "XML documents expected to be different but are equal"
     end
 
@@ -88,11 +88,11 @@ module NokogiriMatchers
       actual_text.gsub(/\s+/,' ').include? expected_text.gsub(/\s+/,' ')
     end
 
-    failure_message_for_should do |actual_xml_string|
+    failure_message do |actual_xml_string|
       "Document expected to contain \"#{expected_text}\". Actual:\n#{actual_xml_string}"
     end
 
-    failure_message_for_should_not do |actual_xml_string|
+    failure_message_when_negated do |actual_xml_string|
       "Document expected to not contain \"#{expected_text}\". Actual:\n#{actual_xml_string}"
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,29 +10,33 @@ module Helpers
   end
 
   def stub_auth_request(method, url)
-    stub_request(method, auth_url(url))
+    stub_request(method, url).with(basic_auth: [auth.username, auth.password])
   end
-  
+
   def auth_request(method, url)
-    a_request(method, auth_url(url))
+    a_request(method, url).with(basic_auth: [auth.username, auth.password])
   end
-  
+
   def auth
     @auth ||= Almodovar::DigestAuth.new("realm", "user", "password")
-  end
-  
-  def auth_url(url)
-    URI.parse(url).tap do |uri|
-      uri.user = auth.username
-      uri.password = auth.password
-    end.to_s
   end
 end
 
 RSpec.configure do |config|
   config.include Helpers
   config.include WebMock::API
-  config.after(:each) { WebMock.reset! }
+  config.before(:suite) do
+    $default_options = Almodovar.default_options.dup
+  end
+  config.before(:each) do |example|
+    unless example.metadata[:skip_force_basic_auth]
+      Almodovar.default_options = $default_options.merge(force_basic_auth: true)
+    end
+  end
+  config.after(:each) do
+    WebMock.reset!
+    Almodovar.default_options = $default_options
+  end
 end
 
 module NokogiriMatchers
@@ -45,37 +49,37 @@ module NokogiriMatchers
       "expected to have #{processing_instruction} at the beggining of xml:\n#{xml_string}"
     end
   end
-  
+
   RSpec::Matchers.define :match_xpath do |xpath|
     match do |xml_string|
       Nokogiri::XML.parse(xml_string).at_xpath(xpath) != nil
     end
-    
+
     failure_message_for_should do |xml_string|
       "expected to match xpath #{xpath} in xml:\n#{xml_string}"
     end
-    
+
     failure_message_for_should_not do |xml_string|
       "expected to not match xpath #{xpath} in xml:\n#{xml_string}"
     end
-    
+
   end
-  
+
   RSpec::Matchers.define :equal_xml do |expected_xml_string|
     match do |actual_xml_string|
       @expected_doc = Nokogiri.parse(expected_xml_string)
       @actual_doc   = Nokogiri.parse(actual_xml_string)
       Lorax::Signature.new(@expected_doc.root).signature == Lorax::Signature.new(@actual_doc.root).signature
     end
-    
+
     failure_message_for_should do |actual_xml_string|
       "XML documents expected to be the same:\n\nExpected:\n#{expected_xml_string}\n\nActual:\n#{actual_xml_string}"
     end
-    
+
     failure_message_for_should_not do |actual_xml_string|
       "XML documents expected to be different but are equal"
     end
-    
+
   end
 
   RSpec::Matchers.define :have_text do |expected_text|

--- a/spec/unit/collection_call_spec.rb
+++ b/spec/unit/collection_call_spec.rb
@@ -1,42 +1,42 @@
 require 'spec_helper'
 
 describe "Almodovar::Resource#collection_call?" do
-  
+
   let(:resource) { Almodovar::Resource.new(nil, nil) }
-  
+
   it "should be true for size" do
-    resource.send(:collection_call?, :size).should be_true
+    resource.send(:collection_call?, :size).should be true
   end
-  
+
   it "should be true for first" do
-    resource.send(:collection_call?, :first).should be_true
+    resource.send(:collection_call?, :first).should be true
   end
-  
+
   it "should be true for last" do
-    resource.send(:collection_call?, :last).should be_true
+    resource.send(:collection_call?, :last).should be true
   end
-  
+
   it "should be true for [n]" do
-    resource.send(:collection_call?, :[], 1).should be_true
+    resource.send(:collection_call?, :[], 1).should be true
   end
-  
+
   it "should be true for create" do
-    resource.send(:collection_call?, :create).should be_true
+    resource.send(:collection_call?, :create).should be true
   end
-  
+
   it "should be false for ['string']" do
-    resource.send(:collection_call?, :[], 'string').should be_false
+    resource.send(:collection_call?, :[], 'string').should be false
   end
-  
+
   it "should be false for [:s]" do
-    resource.send(:collection_call?, :[], :symbol).should be_false
+    resource.send(:collection_call?, :[], :symbol).should be false
   end
-  
+
   it "should be false for id" do
-    resource.send(:collection_call?, :id).should be_false
+    resource.send(:collection_call?, :id).should be false
   end
-  
+
   it "should be false for delete" do
-    resource.send(:collection_call?, :delete).should be_false
+    resource.send(:collection_call?, :delete).should be false
   end
 end

--- a/spec/unit/collection_call_spec.rb
+++ b/spec/unit/collection_call_spec.rb
@@ -5,38 +5,38 @@ describe "Almodovar::Resource#collection_call?" do
   let(:resource) { Almodovar::Resource.new(nil, nil) }
 
   it "should be true for size" do
-    resource.send(:collection_call?, :size).should be true
+    expect(resource.send(:collection_call?, :size)).to be true
   end
 
   it "should be true for first" do
-    resource.send(:collection_call?, :first).should be true
+    expect(resource.send(:collection_call?, :first)).to be true
   end
 
   it "should be true for last" do
-    resource.send(:collection_call?, :last).should be true
+    expect(resource.send(:collection_call?, :last)).to be true
   end
 
   it "should be true for [n]" do
-    resource.send(:collection_call?, :[], 1).should be true
+    expect(resource.send(:collection_call?, :[], 1)).to be true
   end
 
   it "should be true for create" do
-    resource.send(:collection_call?, :create).should be true
+    expect(resource.send(:collection_call?, :create)).to be true
   end
 
   it "should be false for ['string']" do
-    resource.send(:collection_call?, :[], 'string').should be false
+    expect(resource.send(:collection_call?, :[], 'string')).to be false
   end
 
   it "should be false for [:s]" do
-    resource.send(:collection_call?, :[], :symbol).should be false
+    expect(resource.send(:collection_call?, :[], :symbol)).to be false
   end
 
   it "should be false for id" do
-    resource.send(:collection_call?, :id).should be false
+    expect(resource.send(:collection_call?, :id)).to be false
   end
 
   it "should be false for delete" do
-    resource.send(:collection_call?, :delete).should be false
+    expect(resource.send(:collection_call?, :delete)).to be false
   end
 end

--- a/spec/unit/default_options_spec.rb
+++ b/spec/unit/default_options_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Almodovar do
-  describe '.default_options' do
+  describe '.default_options', :skip_force_basic_auth do
     it 'should return set default_options' do
       expect(Almodovar.default_options[:send_timeout]).to eq(Almodovar::DEFAULT_SEND_TIMEOUT)
       expect(Almodovar.default_options[:connect_timeout]).to eq(Almodovar::DEFAULT_CONNECT_TIMEOUT)

--- a/spec/unit/http_client_spec.rb
+++ b/spec/unit/http_client_spec.rb
@@ -15,15 +15,16 @@ describe Almodovar::HttpClient do
   end
 
   it "allows URI escaped characters in password" do
-    stub_request(:get, "http://username:%5B%5D@www.bebanjo.com/")
+    stub_request(:get, "http://www.bebanjo.com/")
 
     client = Almodovar::HttpClient.new.tap do |client|
+      client.force_basic_auth = true
       client.username = 'username'
       client.password = '[]'
     end
 
     client.get("http://www.bebanjo.com")
 
-    a_request(:get, "http://username:%5B%5D@www.bebanjo.com").should have_been_made
+    a_request(:get, "http://www.bebanjo.com").with(basic_auth: ['username', '[]']).should have_been_made
   end
 end

--- a/spec/unit/http_client_spec.rb
+++ b/spec/unit/http_client_spec.rb
@@ -11,7 +11,7 @@ describe Almodovar::HttpClient do
 
     client.get("http://www.bebanjo.com", 'Baz' => 'Oink')
 
-    a_request(:get, "http://www.bebanjo.com").with(:headers => {'Foo' => 'Bar', 'Baz' => 'Oink'}).should have_been_made
+    expect(a_request(:get, "http://www.bebanjo.com").with(:headers => {'Foo' => 'Bar', 'Baz' => 'Oink'})).to have_been_made
   end
 
   it "allows URI escaped characters in password" do
@@ -25,6 +25,6 @@ describe Almodovar::HttpClient do
 
     client.get("http://www.bebanjo.com")
 
-    a_request(:get, "http://www.bebanjo.com").with(basic_auth: ['username', '[]']).should have_been_made
+    expect(a_request(:get, "http://www.bebanjo.com").with(basic_auth: ['username', '[]'])).to have_been_made
   end
 end

--- a/spec/unit/http_client_spec.rb
+++ b/spec/unit/http_client_spec.rb
@@ -9,7 +9,7 @@ describe Almodovar::HttpClient do
       client.headers = {'Foo' => 'Bar', 'Baz' => 'Bas'}
     end
 
-    client.get("http://www.bebanjo.com", 'Baz' => 'Oink')
+    client.get("http://www.bebanjo.com", {}, {'Baz' => 'Oink'})
 
     expect(a_request(:get, "http://www.bebanjo.com").with(headers: {'Foo' => 'Bar', 'Baz' => 'Oink'})).to have_been_made
   end

--- a/spec/unit/http_client_spec.rb
+++ b/spec/unit/http_client_spec.rb
@@ -11,7 +11,7 @@ describe Almodovar::HttpClient do
 
     client.get("http://www.bebanjo.com", 'Baz' => 'Oink')
 
-    expect(a_request(:get, "http://www.bebanjo.com").with(:headers => {'Foo' => 'Bar', 'Baz' => 'Oink'})).to have_been_made
+    expect(a_request(:get, "http://www.bebanjo.com").with(headers: {'Foo' => 'Bar', 'Baz' => 'Oink'})).to have_been_made
   end
 
   it "allows URI escaped characters in password" do

--- a/spec/unit/to_xml_spec.rb
+++ b/spec/unit/to_xml_spec.rb
@@ -5,7 +5,7 @@ describe Hash do
   describe "to_xml" do
     
     it "should convert the nested resources into 'link' tags if the :convert_links option is present" do
-      xml = Nokogiri::XML.parse({"name" => "Almodovar", "tasks" => [{"name" => "Wadus"}]}.to_xml(:root => "project", :convert_links => true, :skip_links_one_level => true))
+      xml = Nokogiri::XML.parse({"name" => "Almodovar", "tasks" => [{"name" => "Wadus"}]}.to_xml(root: "project", convert_links: true, skip_links_one_level: true))
       
       # <project>
       #   <name>Almodovar</name>
@@ -23,7 +23,7 @@ describe Hash do
     end
     
     it "should not convert the nested resources into 'link' tags if the :convert_links option is not present" do
-      xml = Nokogiri::XML.parse({"name" => "Almodovar", "tasks" => [{"name" => "Wadus"}]}.to_xml(:root => "project", :convert_links => false))
+      xml = Nokogiri::XML.parse({"name" => "Almodovar", "tasks" => [{"name" => "Wadus"}]}.to_xml(root: "project", convert_links: false))
 
       # <project>
       #   <name>Almodovar</name>

--- a/spec/unit/to_xml_spec.rb
+++ b/spec/unit/to_xml_spec.rb
@@ -17,9 +17,9 @@ describe Hash do
       #     </tasks>
       #   </link>
       # </project>
-      xml.at_xpath("/project/name").text.should == "Almodovar"
-      xml.at_xpath("/project/tasks").should be_nil
-      xml.at_xpath("/project/link[@rel='tasks']/tasks[@type='array']/task/name").text.should == "Wadus"
+      expect(xml.at_xpath("/project/name").text).to eq("Almodovar")
+      expect(xml.at_xpath("/project/tasks")).to be_nil
+      expect(xml.at_xpath("/project/link[@rel='tasks']/tasks[@type='array']/task/name").text).to eq("Wadus")
     end
     
     it "should not convert the nested resources into 'link' tags if the :convert_links option is not present" do
@@ -33,9 +33,9 @@ describe Hash do
       #     </task>
       #   </tasks>
       # </project>      
-      xml.at_xpath("/project/name").text.should == "Almodovar"
-      xml.at_xpath("//link").should be_nil
-      xml.at_xpath("/project/tasks[@type='array']/task/name").text.should == "Wadus"
+      expect(xml.at_xpath("/project/name").text).to eq("Almodovar")
+      expect(xml.at_xpath("//link")).to be_nil
+      expect(xml.at_xpath("/project/tasks[@type='array']/task/name").text).to eq("Wadus")
     end
     
     
@@ -48,14 +48,14 @@ describe Array do
   describe "to_xml" do
     
     it "should convert an array into xml" do
-      [].to_xml.should == "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<nil-classes type=\"array\"/>\n"
+      expect([].to_xml).to eq("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<nil-classes type=\"array\"/>\n")
     end
     
     it "should be able to receive a block" do
       xml = [{}].to_xml { |xml| xml.wadus "Almodovar" }
       xml = Nokogiri::XML.parse(xml)
 
-      xml.at_xpath("//wadus").text.should == "Almodovar"
+      expect(xml.at_xpath("//wadus").text).to eq("Almodovar")
     end
 
   end

--- a/spec/unit/unprocessable_entity_error_spec.rb
+++ b/spec/unit/unprocessable_entity_error_spec.rb
@@ -25,7 +25,7 @@ describe Almodovar::UnprocessableEntityError do
         </errors>
       }
       error = unprocessable_entity_error(double_response(body))
-      error.error_messages.should eq(['Name is taken'])
+      expect(error.error_messages).to eq(['Name is taken'])
 
 
       body = %q{
@@ -35,7 +35,7 @@ describe Almodovar::UnprocessableEntityError do
         </errors>
       }
       error = unprocessable_entity_error(double_response(body))
-      error.error_messages.should eq(['Name is taken', 'External ID is required'])
+      expect(error.error_messages).to eq(['Name is taken', 'External ID is required'])
 
       body = %q{
         <error>
@@ -43,20 +43,20 @@ describe Almodovar::UnprocessableEntityError do
         </error>
       }
       error = unprocessable_entity_error(double_response(body))
-      error.error_messages.should eq(['per_page maximum value is 200'])
+      expect(error.error_messages).to eq(['per_page maximum value is 200'])
     end
 
     it 'returns an empty array on empty response bodies' do
       error = unprocessable_entity_error(double_response(''))
-      error.error_messages.should eq([])
+      expect(error.error_messages).to eq([])
 
       error = unprocessable_entity_error(double_response(nil))
-      error.error_messages.should eq([])
+      expect(error.error_messages).to eq([])
     end
 
     it 'returns an empty array on json response bodies (it\'s not supported from the moment)' do
       error = unprocessable_entity_error(double_response('{"wadus": "foo"}'))
-      error.error_messages.should eq([])
+      expect(error.error_messages).to eq([])
     end
   end
 


### PR DESCRIPTION
This PR implements #26

This PR not only update some dependencies, up to support ruby 1.9 which probably we want do deprecate pretty soon too.

After opening this I've realised that there is other PR open to solve the same [problem](https://github.com/bebanjo/almodovar/pull/44) I've thought on that but IMHO it's better to delegate that encoding to the underlying http client, in our case HTTPClient.

/cc @demimismo @AlfonsoUceda 

In anyway we need to merge one of those solutions as it's blocking us.