### PR TITLE
Upgrade to nokogiri to a version without vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,4 @@ gem 'lorax'
 gem 'rdoc'
 
 gem 'activesupport', '>= 3.1.0'
-gem 'nokogiri', '~> 1.8.1'
+gem 'nokogiri', '~> 1.8.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       httpclient (~> 2.5)
       i18n
       json
-      nokogiri
+      nokogiri (~> 1.8.2)
 
 GEM
   remote: https://rubygems.org/
@@ -31,7 +31,7 @@ GEM
       nokogiri (>= 1.4.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     rake (10.1.1)
     rdoc (4.1.1)
@@ -65,7 +65,7 @@ DEPENDENCIES
   activesupport (>= 3.1.0)
   almodovar!
   lorax
-  nokogiri (~> 1.8.1)
+  nokogiri (~> 1.8.2)
   rake
   rdoc
   rspec

--- a/almodovar.gemspec
+++ b/almodovar.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths     = ["lib"]
 
   s.add_runtime_dependency("builder")
-  s.add_runtime_dependency("nokogiri")
+  s.add_runtime_dependency("nokogiri", "~> 1.8.2")
   s.add_runtime_dependency("activesupport")
   s.add_runtime_dependency("i18n")
   s.add_runtime_dependency("httpclient", "~> 2.5")


### PR DESCRIPTION
Upgrade to nokogiri to a version without vulnerabilities

https://nvd.nist.gov/vuln/detail/CVE-2017-18258

/cc @AlfonsoUceda 