### PR TITLE
Upgrade nokogiri

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,5 @@ before_install:
   # Lastest version of bundler require ruby > 2.3
   - gem install bundler -v 1.17.1 --no-ri --no-rdoc
 rvm:
-  - 2.1.10
-  - 2.2.9
   - 2.3.6
   - 2.4.3

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,9 @@ gemspec
 
 gem 'rake'
 gem 'rspec'
-gem 'webmock', '2.3.2' # Last ruby 1.9 support
+gem 'webmock'
 gem 'safe_yaml', '>= 1.0.4'
-gem 'lorax'
 gem 'rdoc'
 
 gem 'activesupport', '>= 3.1.0'
-gem 'nokogiri', '~> 1.8.2'
+gem 'nokogiri', '~> 1.10.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       httpclient (~> 2.5)
       i18n
       json
-      nokogiri (~> 1.8, >= 1.8.2)
+      nokogiri (~> 1.10.4)
 
 GEM
   remote: https://rubygems.org/
@@ -18,23 +18,21 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     builder (3.2.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    hashdiff (0.3.8)
+    hashdiff (1.0.0)
     httpclient (2.8.3)
     i18n (0.8.1)
     json (1.8.6)
-    lorax (0.2.0)
-      nokogiri (>= 1.4.0)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.10.3)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
-    public_suffix (3.0.3)
+    nokogiri (1.10.4)
+      mini_portile2 (~> 2.4.0)
+    public_suffix (3.1.1)
     rake (10.1.1)
     rdoc (4.1.1)
       json (~> 1.4)
@@ -51,14 +49,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     thread_safe (0.3.6)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
-    webmock (2.3.2)
+    webmock (3.6.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
@@ -66,13 +64,12 @@ PLATFORMS
 DEPENDENCIES
   activesupport (>= 3.1.0)
   almodovar!
-  lorax
-  nokogiri (~> 1.8.2)
+  nokogiri (~> 1.10.4)
   rake
   rdoc
   rspec
   safe_yaml (>= 1.0.4)
-  webmock (= 2.3.2)
+  webmock
 
 BUNDLED WITH
    1.17.3

--- a/almodovar.gemspec
+++ b/almodovar.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths     = ["lib"]
 
   s.add_runtime_dependency("builder")
-  s.add_runtime_dependency("nokogiri", "~> 1.8", '>= 1.8.2')
+  s.add_runtime_dependency("nokogiri", "~> 1.10.4")
   s.add_runtime_dependency("activesupport")
   s.add_runtime_dependency("i18n")
   s.add_runtime_dependency("httpclient", "~> 2.5")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'rubygems'
 require 'webmock/rspec'
-require 'lorax'
 require 'almodovar'
 
 module Helpers
@@ -36,64 +35,5 @@ RSpec.configure do |config|
   config.after(:each) do
     WebMock.reset!
     Almodovar.default_options = $default_options
-  end
-end
-
-module NokogiriMatchers
-  RSpec::Matchers.define :have_processing_instruction do |processing_instruction|
-    match do |xml_string|
-      xml_string.starts_with?(processing_instruction)
-    end
-
-    failure_message do |xml_string|
-      "expected to have #{processing_instruction} at the beggining of xml:\n#{xml_string}"
-    end
-  end
-
-  RSpec::Matchers.define :match_xpath do |xpath|
-    match do |xml_string|
-      Nokogiri::XML.parse(xml_string).at_xpath(xpath) != nil
-    end
-
-    failure_message do |xml_string|
-      "expected to match xpath #{xpath} in xml:\n#{xml_string}"
-    end
-
-    failure_message_when_negated do |xml_string|
-      "expected to not match xpath #{xpath} in xml:\n#{xml_string}"
-    end
-
-  end
-
-  RSpec::Matchers.define :equal_xml do |expected_xml_string|
-    match do |actual_xml_string|
-      @expected_doc = Nokogiri.parse(expected_xml_string)
-      @actual_doc   = Nokogiri.parse(actual_xml_string)
-      Lorax::Signature.new(@expected_doc.root).signature == Lorax::Signature.new(@actual_doc.root).signature
-    end
-
-    failure_message do |actual_xml_string|
-      "XML documents expected to be the same:\n\nExpected:\n#{expected_xml_string}\n\nActual:\n#{actual_xml_string}"
-    end
-
-    failure_message_when_negated do |actual_xml_string|
-      "XML documents expected to be different but are equal"
-    end
-
-  end
-
-  RSpec::Matchers.define :have_text do |expected_text|
-    match do |actual_xml_string|
-      actual_text = Nokogiri.parse(actual_xml_string).text
-      actual_text.gsub(/\s+/,' ').include? expected_text.gsub(/\s+/,' ')
-    end
-
-    failure_message do |actual_xml_string|
-      "Document expected to contain \"#{expected_text}\". Actual:\n#{actual_xml_string}"
-    end
-
-    failure_message_when_negated do |actual_xml_string|
-      "Document expected to not contain \"#{expected_text}\". Actual:\n#{actual_xml_string}"
-    end
   end
 end


### PR DESCRIPTION
We're upgrading the minimum Nokogiri version to address [CVE-2019-5477](https://nvd.nist.gov/vuln/detail/CVE-2019-5477). This change forces us to stop supporting Ruby versions < 2.3.

I'm also removing an unneeded dependency and some unused RSpec matchers.