### PR TITLE
Add specific TooManyRequestsError class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,6 @@ jobs:
 
       - name: Build and test with Rake
         run: |
-          gem install bundler
+          gem install bundler -v 1.17.3
           bundle install --jobs 4 --retry 3
           bundle exec rake

--- a/spec/acceptance/errors_spec.rb
+++ b/spec/acceptance/errors_spec.rb
@@ -5,7 +5,7 @@ describe "Errors should raise exceptions" do
   let(:resource_url)  { "http://movida.example.com/resource" }
   let(:resources_url) { "http://movida.example.com/resources" }
 
-  %w{400 401 403 404 405 406 422 500 502 503}.each do |code|
+  %w{400 401 403 404 405 406 422 429 500 502 503}.each do |code|
     example "Receiving #{code} in a GET request" do
       stub_auth_request(:get, resource_url).to_return(body: '<error>more info</error>', status: code.to_i)
 

--- a/spec/unit/too_many_requests_error_spec.rb
+++ b/spec/unit/too_many_requests_error_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Almodovar::TooManyRequestsError do
+  describe '#ratelimit_reset' do
+    it 'returns the value of the `ratelimit-reset` header' do
+      headers = {
+        "ratelimit-reset"=>"251",
+        "status"=>"429 Too Many Requests"
+      }
+      error = too_many_requests_error(double_response(headers))
+
+      expect(error.ratelimit_reset).to eq '251'
+    end
+  end
+
+  def double_response(headers)
+    double(:response, body: "", headers: headers, status: nil)
+  end
+
+  def too_many_requests_error(response)
+    Almodovar::TooManyRequestsError.new(response, 'http://example.com/api')
+  end
+end

--- a/spec/unit/unprocessable_entity_error_spec.rb
+++ b/spec/unit/unprocessable_entity_error_spec.rb
@@ -61,7 +61,7 @@ describe Almodovar::UnprocessableEntityError do
   end
 
   def double_response(body)
-    double(:response, body: body, status: nil)
+    double(:response, body: body, headers: {}, status: nil)
   end
 
   def unprocessable_entity_error(response)


### PR DESCRIPTION
Adds a new error class for 429 Too Many Requests errors.

### Release

- Merge into master
- Bump gem version and add to History file (like in https://github.com/bebanjo/almodovar/commit/7d052f04b967fb3103644e4e464d87d671ab59cd or https://github.com/bebanjo/almodovar/commit/bdc87b522dd674d2a7b845ffde60c560751ba332)
- Push gem to rubygems
   - gem build almodovar.gemspec
   -  gem push almodovar-1.7.9.gem