### PR TITLE
Update Nokogiri to v1.12 for Ruby 3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.3, 2.4 ]
+        ruby: [ 3.0.0, 2.6 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -16,6 +16,6 @@ jobs:
 
       - name: Build and test with Rake
         run: |
-          gem install bundler -v 1.17.3
+          gem install bundler -v 2.4.1
           bundle install --jobs 4 --retry 3
           bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ gem 'safe_yaml', '>= 1.0.4'
 gem 'rdoc', '5.1.0'
 
 gem 'activesupport', '>= 5.2.4'
-gem 'nokogiri', '~> 1.12.0'
+gem 'nokogiri', '>= 1.12.0'
 gem 'json', '>= 2.3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gem 'webmock'
 gem 'safe_yaml', '>= 1.0.4'
 gem 'rdoc', '5.1.0'
 
-gem 'activesupport', '>= 3.1.0'
-gem 'nokogiri', '~> 1.10.8'
+gem 'activesupport', '>= 5.2.4'
+gem 'nokogiri', '~> 1.12.0'
 gem 'json', '>= 2.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,39 +2,45 @@ PATH
   remote: .
   specs:
     almodovar (1.8.0)
-      activesupport
+      activesupport (~> 5.2.4)
       addressable (>= 2.3.6)
       builder
       httpclient (~> 2.5)
       i18n
       json
-      nokogiri (~> 1.10.4)
+      nokogiri (~> 1.12.0)
+      rexml (>= 3.2.5)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.10)
-      i18n (~> 0.7)
+    activesupport (5.2.8.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    builder (3.2.3)
+    builder (3.2.4)
+    concurrent-ruby (1.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     hashdiff (1.0.1)
     httpclient (2.8.3)
-    i18n (0.8.1)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
     json (2.5.1)
-    mini_portile2 (2.4.0)
-    minitest (5.10.3)
-    nokogiri (1.10.8)
-      mini_portile2 (~> 2.4.0)
+    mini_portile2 (2.6.1)
+    minitest (5.18.0)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     public_suffix (4.0.3)
+    racc (1.6.2)
     rake (13.0.1)
     rdoc (5.1.0)
+    rexml (3.2.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -50,7 +56,7 @@ GEM
     rspec-support (3.9.2)
     safe_yaml (1.0.5)
     thread_safe (0.3.6)
-    tzinfo (1.2.4)
+    tzinfo (1.2.11)
       thread_safe (~> 0.1)
     webmock (3.8.3)
       addressable (>= 2.3.6)
@@ -61,10 +67,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (>= 3.1.0)
+  activesupport (>= 5.2.4)
   almodovar!
   json (>= 2.3.0)
-  nokogiri (~> 1.10.8)
+  nokogiri (~> 1.12.0)
   rake
   rdoc (= 5.1.0)
   rspec
@@ -72,4 +78,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       httpclient (~> 2.5)
       i18n
       json
-      nokogiri (~> 1.12.0)
+      nokogiri (>= 1.12.0)
       rexml (>= 3.2.5)
 
 GEM
@@ -70,7 +70,7 @@ DEPENDENCIES
   activesupport (>= 5.2.4)
   almodovar!
   json (>= 2.3.0)
-  nokogiri (~> 1.12.0)
+  nokogiri (>= 1.12.0)
   rake
   rdoc (= 5.1.0)
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     almodovar (1.8.0)
-      activesupport (~> 5.2.4)
+      activesupport (>= 5.2.4)
       addressable (>= 2.3.6)
       builder
       httpclient (~> 2.5)

--- a/almodovar.gemspec
+++ b/almodovar.gemspec
@@ -17,10 +17,11 @@ Gem::Specification.new do |s|
   s.require_paths     = ["lib"]
 
   s.add_runtime_dependency("builder")
-  s.add_runtime_dependency("nokogiri", "~> 1.10.4")
-  s.add_runtime_dependency("activesupport")
+  s.add_runtime_dependency("nokogiri", "~> 1.12.0")
+  s.add_runtime_dependency("activesupport", "~> 5.2.4")
   s.add_runtime_dependency("i18n")
   s.add_runtime_dependency("httpclient", "~> 2.5")
   s.add_runtime_dependency("addressable", ">= 2.3.6")
   s.add_runtime_dependency("json")
+  s.add_runtime_dependency("rexml", ">= 3.2.5")
 end

--- a/almodovar.gemspec
+++ b/almodovar.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("builder")
   s.add_runtime_dependency("nokogiri", "~> 1.12.0")
-  s.add_runtime_dependency("activesupport", "~> 5.2.4")
+  s.add_runtime_dependency("activesupport", ">= 5.2.4")
   s.add_runtime_dependency("i18n")
   s.add_runtime_dependency("httpclient", "~> 2.5")
   s.add_runtime_dependency("addressable", ">= 2.3.6")

--- a/almodovar.gemspec
+++ b/almodovar.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths     = ["lib"]
 
   s.add_runtime_dependency("builder")
-  s.add_runtime_dependency("nokogiri", "~> 1.12.0")
+  s.add_runtime_dependency("nokogiri", ">= 1.12.0")
   s.add_runtime_dependency("activesupport", ">= 5.2.4")
   s.add_runtime_dependency("i18n")
   s.add_runtime_dependency("httpclient", "~> 2.5")


### PR DESCRIPTION
Related to https://github.com/bebanjo/snitch/issues/154 we realized we couldn't upgrade to Rails 3 because there was a Nokogiri dependency issue in Almodovar.
See also https://github.com/bebanjo/almodovar/pull/71

This bump hopes to solve that.

### Notes for acceptance
The latest Nokogiri version is 1.14.2 but I've stopped at 1.12 as 1.13 introduces some potentially [breaking changes](https://nokogiri.org/CHANGELOG.html#deprecated_2):

<img width="683" alt="image" src="https://user-images.githubusercontent.com/5381777/227029532-f9400483-eef4-4088-991b-9f7c85bc906f.png">

I had to upgrade Activesupport as well because of the error `undefined method `new' for BigDecimal:Class`.

### Release

This should be released as Almodovar v2.0.0
- Merge into master
- Bump gem version and add to History file (like in https://github.com/bebanjo/almodovar/commit/bdc87b522dd674d2a7b845ffde60c560751ba332)
- Push gem to rubygems
  - gem build almodovar.gemspec
  - gem push almodovar-2.0.0.gem
- Update Gemfile of applications that uses this gem (the ones that need to be upgraded to Ruby 3.0).
