### PR TITLE
Add support to specify query params when deleting resources

### DIFF
--- a/lib/almodovar/single_resource.rb
+++ b/lib/almodovar/single_resource.rb
@@ -20,8 +20,8 @@ module Almodovar
       @xml = Nokogiri::XML.parse(response.body).root
     end
 
-    def delete
-      check_errors(http.delete(@url), @url)
+    def delete(extra_query_params = {})
+      check_errors(http.delete(@url, extra_query_params), @url, extra_query_params)
     end
 
     def url

--- a/spec/acceptance/create_resource_spec.rb
+++ b/spec/acceptance/create_resource_spec.rb
@@ -1,17 +1,15 @@
 require 'spec_helper'
 
 describe "Creating new resources" do
-  
   example "Creating a resource in a collection" do
-    
     projects = Almodovar::Resource("http://movida.example.com/projects", auth)
-    
+
     stub_auth_request(:post, "http://movida.example.com/projects").with do |req|
       # we parse because comparing strings is too fragile because of order changing, different indentations, etc.
       # we're expecting something very close to this:
       # <project>
       #   <name>Wadus</name>
-      # </project>      
+      # </project>
       Nokogiri::XML.parse(req.body).at_xpath("/project/name").text == "Wadus"
     end.to_return(body: %q{
       <project>
@@ -19,22 +17,22 @@ describe "Creating new resources" do
         <link rel="self" href="http://movida.example.com/projects/1"/>
       </project>
     })
-    
+
     project = projects.create(project: {name: "Wadus"})
-    
+
     expect(project).to be_a(Almodovar::Resource)
     expect(project.name).to eq("Wadus")
-    
+
     stub_auth_request(:get, "http://movida.example.com/projects/1").to_return(body: %q{
       <project>
         <name>Wadus</name>
         <link rel="self" href="http://movida.example.com/projects/1"/>
       </project>
     })
-    
+
     expect(project.name).to eq(Almodovar::Resource(project.url, auth).name)
   end
-  
+
   example "Creating a resource expanding links" do
     stub_auth_request(:post, "http://movida.example.com/projects?expand=tasks").with do |req|
       # <project>
@@ -58,19 +56,19 @@ describe "Creating new resources" do
         </link>
       </project>
     })
-    
-    projects = Almodovar::Resource("http://movida.example.com/projects", auth, expand: :tasks)    
+
+    projects = Almodovar::Resource("http://movida.example.com/projects", auth, expand: :tasks)
     project = projects.create(project: {name: "Wadus", template: "Basic"})
-    
+
     expect(project).to be_a(Almodovar::Resource)
     expect(project.name).to eq("Wadus")
     expect(project.tasks.size).to eq(1)
     expect(project.tasks.first.name).to eq("Starting Meeting")
   end
-  
+
   example "Creating linking to existing resources" do
     projects = Almodovar::Resource("http://movida.example.com/projects", auth)
-    
+
     stub_auth_request(:post, "http://movida.example.com/projects").with do |req|
       # <project>
       #   <link rel="owner" href="http://example.com/people/luismi"/>
@@ -83,16 +81,16 @@ describe "Creating new resources" do
         <link rel="owner" href="http://example.com/people/luismi"/>
       </project>
     })
-    
+
     project = projects.create(project: {owner: Almodovar::Resource("http://example.com/people/luismi")})
-    
+
     expect(project).to be_a(Almodovar::Resource)
     expect(project.owner.url).to eq("http://example.com/people/luismi")
   end
-  
+
   example "Creating single nested resources" do
     projects = Almodovar::Resource("http://movida.example.com/projects", auth, expand: :tasks)
-    
+
     stub_auth_request(:post, "http://movida.example.com/projects?expand=tasks").with do |req|
       # <project>
       #   <name>Wadus</name>
@@ -117,17 +115,17 @@ describe "Creating new resources" do
         </link>
       </project>
     })
-    
+
     project = projects.create(project: {name: "Wadus", timeline: {name: "Start project", wadus: {}}})
-    
+
     expect(project).to be_a(Almodovar::Resource)
     expect(project.name).to eq("Wadus")
     expect(project.timeline.name).to eq("Start project")
   end
-  
+
   example "Creating multiple nested resources" do
     projects = Almodovar::Resource("http://movida.example.com/projects", auth, expand: :tasks)
-    
+
     stub_auth_request(:post, "http://movida.example.com/projects?expand=tasks").with do |req|
       # <project>
       #   <link rel="tasks">
@@ -151,9 +149,9 @@ describe "Creating new resources" do
         </link>
       </project>
     })
-    
+
     project = projects.create(project: {tasks: [{name: "Start project"}]})
-    
+
     expect(project).to be_a(Almodovar::Resource)
     expect(project.tasks.first.name).to eq("Start project")
   end
@@ -242,5 +240,4 @@ describe "Creating new resources" do
       end
     end.to raise_error(Almodovar::UnprocessableEntityError)
   end
-  
 end

--- a/spec/acceptance/delete_resource_spec.rb
+++ b/spec/acceptance/delete_resource_spec.rb
@@ -1,21 +1,44 @@
 require 'spec_helper'
 
 describe "Deleting resources" do
-  
   example "Deleting a resource" do
-    project = Almodovar::Resource("http://movida.example.com/projects/1", auth)
+    url = "http://movida.example.com/projects/1"
+
+    project = Almodovar::Resource(url, auth)
     
-    stub_auth_request(:delete, "http://movida.example.com/projects/1").to_return(status: 200)
+    stub_auth_request(:delete, url).to_return(status: 200)
     
     project.delete
     
-    expect(auth_request(:delete, "http://movida.example.com/projects/1")).to have_been_made.once
+    expect(auth_request(:delete, url)).to have_been_made.once
+  end
+
+  example "Deleting a resource with query params" do
+    url = "http://movida.example.com/projects/1"
+
+    project = Almodovar::Resource(url, auth)
+
+    stub_auth_request(:delete, url).with({
+      query: {
+        param1: 1,
+        param2: 2,
+      }
+    }).to_return(status: 200)
+
+    project.delete({
+      param1: 1,
+      param2: 2,
+    })
+
+    expect(auth_request(:delete, url + "?param1=1&param2=2")).to have_been_made.once
   end
 
   example "Deleting a resource raise UnprocessableEntityError" do
-    project = Almodovar::Resource("http://movida.example.com/projects/1", auth)
+    url = "http://movida.example.com/projects/1"
 
-    stub_auth_request(:delete, "http://movida.example.com/projects/1").to_return(body: %q{
+    project = Almodovar::Resource(url, auth)
+
+    stub_auth_request(:delete, url).to_return(body: %q{
       <errors>
         <error>Should delete existing tasks first</error>
       </errors>

--- a/spec/acceptance/update_resource_spec.rb
+++ b/spec/acceptance/update_resource_spec.rb
@@ -1,26 +1,29 @@
 require 'spec_helper'
 
 describe "Updating resources" do
-  
   example "Updating a resource" do
-    stub_auth_request(:put, "http://movida.example.com/projects/1").with do |req|
+    url = "http://movida.example.com/projects/1"
+
+    stub_auth_request(:put, url).with do |req|
       req.body == {name: "Wadus Wadus"}.to_xml(root: "project")
     end.to_return(body: <<-XML)
       <project>
         <name>Wadus Wadus</name>
-        <link rel="self" href="http://movida.example.com/projects/1"/>
+        <link rel="self" href="#{url}"/>
       </project>
     XML
-    
-    project = Almodovar::Resource("http://movida.example.com/projects/1", auth)
-    
+
+    project = Almodovar::Resource(url, auth)
+
     project.update(project: {name: "Wadus Wadus"})
-    
+
     expect(project.name).to eq("Wadus Wadus")
   end
-  
+
   example "Updating a document resource" do
-    stub_auth_request(:put, "http://movida.example.com/people/1/extra_data").with do |req|
+    url = "http://movida.example.com/people/1/extra_data"
+
+    stub_auth_request(:put, url).with do |req|
       req.body == {birthplace: "Calzada de Calatrava"}.to_xml(root: "extra-data")
     end.to_return(body: <<-XML)
       <extra-data type="document">
@@ -28,10 +31,9 @@ describe "Updating resources" do
         <birthyear type="integer">1949</birthyear>
       </extra-data>
     XML
-    
-    extra_data = Almodovar::Resource("http://movida.example.com/people/1/extra_data", auth)
-    extra_data.update(extra_data: {birthplace: "Calzada de Calatrava"})
+
+    extra_data = Almodovar::Resource(url, auth)
+    extra_data.update(extra_data: { birthplace: "Calzada de Calatrava" })
     expect(extra_data.birthplace).to eq("Calzada de Calatrava")
   end
-  
 end

--- a/spec/unit/single_resource_spec.rb
+++ b/spec/unit/single_resource_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe Almodovar::SingleResource do
-
   it "#update uses proper Content-Type header" do
+    url = "http://movida.bebanjo.com/titles/1"
 
-    stub_request(:put, "http://movida.bebanjo.com/titles/1")
+    stub_request(:put, url)
 
-    Almodovar::SingleResource.new("http://movida.bebanjo.com/titles/1", nil).update(title: {"name" => "Kamikaze"})
+    Almodovar::SingleResource.new(url, nil).update(title: {"name" => "Kamikaze"})
 
-    expect(a_request(:put, "http://movida.bebanjo.com/titles/1").with(headers: {'Content-Type' => "application/xml"})).to have_been_made
+    expect(a_request(:put, url).with(headers: {'Content-Type' => "application/xml"})).to have_been_made
   end
 
   it "#to_hash" do
@@ -21,5 +21,29 @@ describe Almodovar::SingleResource do
     })
 
     expect(Almodovar::SingleResource.new(url, nil).to_hash).to eq({ "name" => "Resource Name" })
+  end
+
+  it "#delete" do
+    url = "http://movida.bebanjo.com/titles/1"
+
+    stub_request(:delete, url).to_return(status: 200)
+
+    expect(Almodovar::SingleResource.new(url, nil).delete).to be_nil
+  end
+
+  it "#delete with query params" do
+    url = "http://movida.bebanjo.com/titles/1"
+
+    stub_request(:delete, url).with({
+      query: {
+        param1: 1,
+        param2: 2
+      }
+    }).to_return(status: 200)
+
+    expect(Almodovar::SingleResource.new(url, nil).delete({
+      param1: 1,
+      param2: 2
+    })).to be_nil
   end
 end


### PR DESCRIPTION
Fixes bebanjo/bond#1446

## What we did

Update [lib/almodovar/single_resource.rb](https://github.com/bebanjo/almodovar/compare/master...requirements-for-bond-1446#diff-8029d69337b2bb85cb4dcd5a0d9046be07a5bb57fa99110b7232ec6e7fadac1f) in order to allow query param when deleting resources, and with that allow to reload cache or any other related action.

Test cases were updated accordingly

## Inspiration

Reviewing the requirements of [bebanjo/bond#1446](https://github.com/bebanjo/bond/issues/1446) and doing the less intrusive changes to keep backward-compatibility with previous versions.

## Notes for the person doing acceptance

N/A

### Functional acceptance

- [✓] Functional tests passed

### Code Review

- [✓] Reviewed preexisting specs changed or deleted (we shouldn't be relaxing the testing criteria or leaving cases uncovered)
- [✓] Code follows [styleguide][1]
- [✓] Commit messages follow [styleguide][2]

## How to release this

We need to release two versions of the gem: 
- 1.8.1, based on `master-v1.x`, that works with ruby 2.3
- 2.0.1, based on `master`, that works with ruby 3

For 2.0.1:
- Merge this PR into master
- Bump gem version and add to History file
- Create and push git tag for version 2.0.1
- Push gem to rubygems
    - gem build almodovar.gemspec
    - gem push almodovar-2.0.1.gem

For 1.8.1:
- Merge branch https://github.com/bebanjo/almodovar/tree/requirements-for-bond-1446-for-master-v1 into `master-v1.x`
- Bump gem version to 1.8.1 and add to History file (in `master-v1.x`)
- Create and push git tag for version 1.8.1
- Push gem to rubygems
    - gem build almodovar.gemspec
    - gem push almodovar-1.8.1.gem




## Warnings

N/A

[1]:https://github.com/bebanjo/culture/blob/stable/workflow/styleguide/backend-styleguide.md
[2]:https://github.com/bebanjo/culture/blob/stable/workflow/styleguide/git-commit-messages-styleguide.md
 