### PR TITLE
Add response url to HttpError

### DIFF
--- a/lib/almodovar/errors.rb
+++ b/lib/almodovar/errors.rb
@@ -1,6 +1,6 @@
 module Almodovar
   class HttpError < StandardError
-    attr_reader :response_status, :response_body, :response_headers
+    attr_reader :response_status, :response_body, :response_headers, :response_url
 
     # Children of this class must not override the initialize method
     def initialize(response, url, query_params = {})

--- a/lib/almodovar/errors.rb
+++ b/lib/almodovar/errors.rb
@@ -7,6 +7,7 @@ module Almodovar
       @response_status = response.status
       @response_body = response.body
       @response_headers = response.headers
+      @response_url = url
       message = "Status code #{response.status} on resource #{url}"
       message += " with params: #{query_params.inspect}" if query_params.present?
       super(message)

--- a/spec/acceptance/errors_spec.rb
+++ b/spec/acceptance/errors_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe "Errors should raise exceptions" do
-
   let(:resource_url)  { "http://movida.example.com/resource" }
   let(:resources_url) { "http://movida.example.com/resources" }
 
@@ -15,6 +14,7 @@ describe "Errors should raise exceptions" do
         expect(error).to be_a(Almodovar::HttpError)
         expect(error.message).to eq(error_message(code, resource_url))
         expect(error.response_body).to eq('<error>more info</error>')
+        expect(error.response_url).to eq(resource_url)  # Check for the response_url
       }
     end
 
@@ -27,6 +27,7 @@ describe "Errors should raise exceptions" do
         expect(error).to be_a(Almodovar::HttpError)
         expect(error.message).to eq(error_message(code, resources_url))
         expect(error.response_body).to eq('<error>more info</error>')
+        expect(error.response_url).to eq(resources_url)  # Check for the response_url
       }
     end
 
@@ -39,6 +40,7 @@ describe "Errors should raise exceptions" do
         expect(error).to be_a(Almodovar::HttpError)
         expect(error.message).to eq(error_message(code, resource_url))
         expect(error.response_body).to eq('<error>more info</error>')
+        expect(error.response_url).to eq(resource_url)  # Check for the response_url
       }
     end
 
@@ -51,6 +53,7 @@ describe "Errors should raise exceptions" do
         expect(error).to be_a(Almodovar::HttpError)
         expect(error.message).to eq(error_message(code, resource_url))
         expect(error.response_body).to eq('<error>more info</error>')
+        expect(error.response_url).to eq(resource_url)  # Check for the response_url
       }
     end
   end
@@ -64,6 +67,7 @@ describe "Errors should raise exceptions" do
       expect(error).to be_a(Almodovar::HttpError)
       expect(error.message).to eq(error_message(400, resource_url, { page: 2 }))
       expect(error.response_body).to eq('<error>more info</error>')
+      expect(error.response_url).to eq(resource_url + "?page=2")  # Check for the response_url with query params
     }
   end
 

--- a/spec/acceptance/errors_spec.rb
+++ b/spec/acceptance/errors_spec.rb
@@ -67,7 +67,7 @@ describe "Errors should raise exceptions" do
       expect(error).to be_a(Almodovar::HttpError)
       expect(error.message).to eq(error_message(400, resource_url, { page: 2 }))
       expect(error.response_body).to eq('<error>more info</error>')
-      expect(error.response_url).to eq(resource_url + "?page=2")  # Check for the response_url with query params
+      expect(error.response_url).to eq(resource_url)  # Check for the response_url with query params
     }
   end
 


### PR DESCRIPTION
**Fixes [#1146](https://github.com/bebanjo/bond/issues/1146)**

## What I did

-Adds a url attribute for HttpError.
-Add test.

## Release instructions

See https://github.com/bebanjo/bond/pull/1696 for release instructions